### PR TITLE
BicincittaOld: Fix problem in parsing station names with HTML entities

### DIFF
--- a/pybikes/bicincitta.py
+++ b/pybikes/bicincitta.py
@@ -3,6 +3,7 @@
 # Distributed under the LGPL license, see LICENSE.txt
 
 import re
+import HTMLParser
 
 from .base import BikeShareSystem, BikeShareStation
 from . import utils
@@ -43,6 +44,7 @@ class BicincittaOld(BaseSystem):
         scraper.setUserAgent(BicincittaOld._useragent)
 
         data = scraper.request(self.url)
+        data = HTMLParser.HTMLParser().unescape(data)
 
         raw_lat   = re.findall(BicincittaOld._RE_INFO_LAT_CORD,data);
         raw_lng   = re.findall(BicincittaOld._RE_INFO_LNG_CORD,data);


### PR DESCRIPTION
Hi eskerda! Apparently there is a problem in parsing names with HTML entitites. 
See for example Bari in CityBik.es  : http://api.citybik.es/v2/networks/bariinbici .
And all the stations actually available in Bari : http://www.bicincitta.com/citta_v3.asp?id=9&pag=2#GMap . 

The fix in the proposed pull request can be improved, but at least it fix the bicincittaold scaper for parsing data for all the stations.
