### PR TITLE
Add caching for one-url-fits-all networks

### DIFF
--- a/pybikes/contrib/tstcache.py
+++ b/pybikes/contrib/tstcache.py
@@ -1,0 +1,60 @@
+import time
+
+
+class TSTCache(dict):
+    """ TSTCache stands for TimeStamped Test Cache
+
+    This class provides an implementation of a dict that only adds values
+    depending on a test function that should be overriden (always true by
+    default).
+
+    It is timestamped because data is added with a timestamp. When timedelta is
+    greater than a predefined delta it will also return None
+    """
+
+    def __init__(self, store=None, delta=60, *args, **kwargs):
+        if store is None:
+            store = {}
+        self.store = store
+        self.delta = delta
+        self.update(dict(*args, **kwargs))
+
+    def __setitem__(self, key, value):
+        key = self.__transform_key__(key)
+        if not self.__test_key__(key):
+            return
+        self.store[key] = {
+            'value': value,
+            'ts': time.time()
+        }
+
+    def __getitem__(self, key):
+        key = self.__transform_key__(key)
+        if not self.__test_key__(key):
+            raise KeyError('%s' % key)
+        if key not in self.store:
+            raise KeyError('%s' % key)
+        ts_value = self.store[key]
+        if time.time() - ts_value['ts'] > self.delta:
+            raise KeyError('%s' % key)
+        return ts_value['value']
+
+    def __contains__(self, key):
+        key = self.__transform_key__(key)
+        try:
+            self[key]
+        except Exception:
+            return False
+        return True
+
+    def __iter__(self):
+        return iter(self.store)
+
+    def __len__(self):
+        return len(self.store)
+
+    def __test_key__(self, key):
+        return True
+
+    def __transform_key__(self, key):
+        return key

--- a/pybikes/nextbike.py
+++ b/pybikes/nextbike.py
@@ -3,16 +3,18 @@
 # Distributed under the AGPL license, see LICENSE.txt
 
 import re
-
 from lxml import etree
 
 from .base import BikeShareSystem, BikeShareStation
 from . import utils
+from .contrib.tstcache import TSTCache
 
 __all__ = ['Nextbike', 'NextbikeStation']
 
 BASE_URL = 'https://nextbike.net/maps/nextbike-live.xml?domains={domain}'
 CITY_QUERY = '/markers/country/city[@uid="{uid}"]/place'
+
+cache = TSTCache(delta=60)
 
 class Nextbike(BikeShareSystem):
     sync = True
@@ -29,7 +31,7 @@ class Nextbike(BikeShareSystem):
 
     def update(self, scraper = None):
         if scraper is None:
-            scraper = utils.PyBikesScraper()
+            scraper = utils.PyBikesScraper(cache)
         domain_xml = etree.fromstring(
             scraper.request(self.url).encode('utf-8'))
         places = domain_xml.xpath(CITY_QUERY.format(uid = self.uid))

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -44,10 +44,11 @@ class PyBikesScraper(object):
     proxy_enabled = False
     last_request = None
 
-    def __init__(self):
+    def __init__(self, cachedict = None):
         self.headers = { 'User-Agent': 'PyBikes' }
         self.proxies = {}
         self.session = requests.session()
+        self.cachedict = cachedict
 
     def setUserAgent(self, user_agent):
         self.headers['User-Agent'] = user_agent
@@ -82,6 +83,8 @@ class PyBikesScraper(object):
         if 'set-cookie' in response.headers:
             self.headers['Cookie'] = response.headers['set-cookie']
         self.last_request = response
+        if self.cachedict is not None:
+            self.cachedict[url] = data
         return data
 
     def clearCookie(self):


### PR DESCRIPTION
Some networks provide one url for multiple networks at the same time. We do not want to do unnecessary requests to providers that play nice, so a timestamp based rate-limiting <url, response> makes these kind of providers compatible with the pybikes architecture.

This branch fixes Issue #22.