### PR TITLE
Adding Belfast Bikes support

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -1,6 +1,18 @@
 {
     "instances": [
         {
+          "domain": "bu",
+          "tag": "belfast-bikes",
+          "meta": {
+              "latitude": 54.59488,
+              "city": "Belfast",
+              "name": "Belfast Bikes",
+              "longitude": -5.9266323,
+              "country": "UK"
+          },
+          "city_uid": 238
+        },
+        {
             "domain": "mb", 
             "tag": "bubi", 
             "meta": {


### PR DESCRIPTION
Support for Belfast Bikes operated by Nextbike:
http://www.belfastbikes.co.uk/en/belfast/