### PR TITLE
Decobike updates

### DIFF
--- a/pybikes/data/decobike.json
+++ b/pybikes/data/decobike.json
@@ -8,19 +8,8 @@
                 "longitude":-80.1300455,
                 "country":"US"
             },
-            "endpoint":"http://www.decobike.com",
+            "feed_url":"http://www.citibikemiami.com/downtown-miami-locations.xml",
             "tag":"decobike-miami-beach"
-        },
-        {
-            "meta":{
-                "latitude":40.5884373,
-                "city":"Long Beach, NY",
-                "name":"DecoBike Long Beach",
-                "longitude":-73.65790799999999,
-                "country":"US"
-            },
-            "endpoint":"http://www.decobikelbny.com",
-            "tag":"decobike-long-beach"
         },
         {
             "meta":{
@@ -30,7 +19,7 @@
                 "longitude":-117.1610838,
                 "country":"US"
             },
-            "endpoint":"http://www.decobike.com/sandiego/",
+            "feed_url":"http://www.decobike.com/sandiego/playmoves.xml",
             "tag":"decobike-san-diego"
         }
     ],

--- a/pybikes/decobike.py
+++ b/pybikes/decobike.py
@@ -9,9 +9,6 @@ from pybikes.utils import PyBikesScraper
 
 __all__ = ['DecoBike']
 
-FEED = "{endpoint}/playmoves.xml"
-
-
 class DecoBike(BikeShareSystem):
     sync = True
 
@@ -20,9 +17,9 @@ class DecoBike(BikeShareSystem):
         'company': 'DecoBike LLC'
     }
 
-    def __init__(self, tag, meta, endpoint):
+    def __init__(self, tag, meta, feed_url):
         super(DecoBike, self).__init__(tag, meta)
-        self.feed_url = FEED.format(endpoint=endpoint)
+        self.feed_url = feed_url
 
     def update(self, scraper=None):
         if scraper is None:


### PR DESCRIPTION
(1) Decobikelbny does not exist anymore.
(2) Decobike Miami has been rebranded to Citi Bike Miami, but still operated by DecoBike.
(3) New feed url for Miami Beach, which contains update stations' information.