### PR TITLE
Adding name to latitude and longitude in the hash generation

### DIFF
--- a/pybikes/base.py
+++ b/pybikes/base.py
@@ -66,7 +66,7 @@ class BikeShareStation(object):
             reliable information about an station that defines the
             difference between one and another
         """
-        str_rep = "%d,%d" % (int(self.latitude * 1E6), int(self.longitude * 1E6))
+        str_rep = "%s,%d,%d" % (self.name, int(self.latitude * 1E6), int(self.longitude * 1E6))
         h = hashlib.md5()
         h.update(str_rep.encode('utf-8'))
         return h.hexdigest()

--- a/pybikes/base.py
+++ b/pybikes/base.py
@@ -62,8 +62,8 @@ class BikeShareStation(object):
 
     def get_hash(self):
         """ Return a unique hash representing this station, usually with
-            latitude and longitude, since it's the only globally ready and
-            reliable information about an station that defines the
+            name, latitude and longitude, since it's the only globally ready
+            and reliable information about an station that defines the
             difference between one and another
         """
         str_rep = "%s,%d,%d" % (self.name, int(self.latitude * 1E6), int(self.longitude * 1E6))


### PR DESCRIPTION
Latitude and longitude alone are not a reliable way to obtain a hash that represents uniquely the stations.
For instance, consider Sevici's stations "213_AVENIDA DE ANDALUCIA" and "214_AVENIDA DE ANDALUCIA", both have same pair of latitude and longitude: (37.3871434869, -5.94841005455)
Furthermore, some systems do not have reliable information of latitude and longitude, e.g., Cyclocity Stockholm, reports (0.0, 0.0) for 4 out of 5 stations (refer to the extract bellow).
This PR aims to improve that by adding the station name in the info to be hashed.

```python
# Without fix
stockholm = pybikes.get('stockholm-cyclocity', '4b780b841057c43770f03bd06c8d30a7c41f9200')
stockholm.update()
for station in stockholm.stations:
	print station.get_hash(), station.name, station.latitude, station.longitude
```
```
# output
fc3ce29e4cbee5e7185f3b528b4dd1bc VOLVO VAK 0.0 0.0
2cdf5487aa0d83466c8d2494408906fa DJURGĂRDEN 59.32419 18.10028
fc3ce29e4cbee5e7185f3b528b4dd1bc VOLVO PV 0.0 0.0
fc3ce29e4cbee5e7185f3b528b4dd1bc VOLVOCITY 0.0 0.0
fc3ce29e4cbee5e7185f3b528b4dd1bc VOLVO PVE 0.0 0.0
```
```
# Output with fix
292d521cf46282c8a776eab6af284974 VOLVO VAK 0.0 0.0
3d36932c64ac7e7ff8b6b8b55ec89a11 DJURGĂRDEN 59.32419 18.10028
e8f8d8498f7cf9dbe31fb4edf3410b5a VOLVO PV 0.0 0.0
cc8086b944e98b698e697f4c5c080249 VOLVOCITY 0.0 0.0
f9632d7b5edb16b789e1de331f881428 VOLVO PVE 0.0 0.0
```