### PR TITLE
[bicincitta] Bicincitta Fossano is over

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -214,17 +214,6 @@
                 },
                 {
                     "meta": {
-                        "latitude": 44.550723,
-                        "city": "Fossano",
-                        "name": "Fossano",
-                        "longitude": 7.7215,
-                        "country": "IT"
-                    },
-                    "tag": "fossano",
-                    "endpoint": "http://www.bicincittabip.com/frmLeStazioni.aspx?ID=107"
-                },
-                {
-                    "meta": {
                         "latitude": 41.645081,
                         "city": "Frosinone",
                         "name": "FRee Bike sharing",


### PR DESCRIPTION
Fossano system has been turned off. Bellow are some of the news to confirm that:

http://www.targatocn.it/2015/09/18/leggi-notizia/argomenti/fossanese/articolo/fossano-le-due-ruote-di-bicincitta-ai-volontari-del-decoro-urbano-e-allufficio-turistico.html

http://www.targatocn.it/2015/05/22/leggi-notizia/argomenti/attualita/articolo/a-fossano-giunge-al-capolinea-bicincitta-disfatta-evitabile-o-naturale-conclusione.html