### PR TITLE
[bicincitta] Alba data is not updated in BicincittaOld

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -170,6 +170,17 @@
                 },
                 {
                     "meta": {
+                        "name": "Alba",
+                        "city": "Alba",
+                        "country": "IT",
+                        "latitude": 44.716667,
+                        "longitude": 8.083333
+                    },
+                    "tag": "alba",
+                    "endpoint": "http://www.bicincittabip.com/frmLeStazioni.aspx?ID=139"
+                },
+                {
+                    "meta": {
                         "latitude": 45.5775,
                         "city": "Biella",
                         "name": "Biella",
@@ -869,17 +880,6 @@
         },
         "BicincittaOld": {
             "instances": [
-                {
-                    "tag": "alba",
-                    "system_id": 15,
-                    "meta": {
-                        "name": "Alba",
-                        "city": "Alba",
-                        "country": "IT",
-                        "latitude": 44.716667,
-                        "longitude": 8.083333
-                    }
-                },
                 {
                     "tag": "bariinbici",
                     "system_id": 9,

--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -192,6 +192,28 @@
                 },
                 {
                     "meta": {
+                        "name": "Chivasso",
+                        "city": "Chivasso",
+                        "country": "IT",
+                        "latitude": 45.189765,
+                        "longitude": 7.888935
+                    },
+                    "tag": "chivasso",
+                    "endpoint": "http://www.bicincittabip.com/frmLeStazioni.aspx?ID=201"
+                },
+                {
+                    "meta": {
+                        "name": "Comunità Montana Valli dell'Ossola",
+                        "city": "Santa Maria Maggiore - Malesco - Villette",
+                        "country": "IT",
+                        "latitude": 46.127196,
+                        "longitude": 8.499169
+                    },
+                    "tag": "ossola",
+                    "endpoint": "http://www.bicincittabip.com/frmLeStazioni.aspx?ID=152"
+                },
+                {
+                    "meta": {
                         "latitude": 45.610555,
                         "city": "Busto Arsizio",
                         "name": "Bici in Busto",
@@ -933,28 +955,6 @@
                         "country": "IT",
                         "latitude": 44.983499,
                         "longitude": 10.419245
-                    }
-                },
-                {
-                    "tag": "chivasso",
-                    "system_id": 11,
-                    "meta": {
-                        "name": "Chivasso",
-                        "city": "Chivasso",
-                        "country": "IT",
-                        "latitude": 45.189765,
-                        "longitude": 7.888935
-                    }
-                },
-                {
-                    "tag": "ossola",
-                    "system_id": 17,
-                    "meta": {
-                        "name": "Comunità Montana Valli dell'Ossola",
-                        "city": "Santa Maria Maggiore - Malesco - Villette",
-                        "country": "IT",
-                        "latitude": 46.127196,
-                        "longitude": 8.499169
                     }
                 },
                 {


### PR DESCRIPTION
Alba's [*edit*: Chivasso and Ossola too] Bincincitta Old system does not report good information on the map. Contrarily, the bicincittabip does.

New: http://www.bicincittabip.com/frmLeStazioni.aspx?ID=139
Old: http://www.bicincitta.com/citta_v3.asp?id=15&pag=2