### PR TITLE
[bicincitta] Removing the duplicate Mantova

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -969,17 +969,6 @@
                     }
                 },
                 {
-                    "tag": "mantova",
-                    "system_id": 53,
-                    "meta": {
-                        "name": "Mantova",
-                        "city": "Mantova",
-                        "country": "IT",
-                        "latitude": 45.15983,
-                        "longitude": 10.793467
-                    }
-                },
-                {
                     "tag": "noviligure",
                     "system_id": 22,
                     "meta": {


### PR DESCRIPTION
With the addition of 10 cities on my commit a4baa1aef02d0fb3d9237e7a8fc57db343ea1f80, Mantova ended up being duplicate, removing the one from the old system now.