### PR TITLE
[utils] Adding timeout to request

### DIFF
--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -70,6 +70,8 @@ class PyBikesScraper(object):
         if self.proxy_enabled and url_scheme(url) == 'https':
             response, data = self.__proxy_https_req__(url)
         else:
+            # Timeout slightly larger than a multiple of 3, which
+            # is the default TCP packet retransmission window
             response = self.session.request(
                 method = method,
                 url = url,
@@ -77,7 +79,8 @@ class PyBikesScraper(object):
                 data = data,
                 proxies = self.getProxies(),
                 headers = self.headers,
-                verify = False
+                verify = False,
+                timeout = 17
             )
             data = response.text
         if 'set-cookie' in response.headers:


### PR DESCRIPTION
Depending on the state of the server we are crawling the data, pybikes may hang and not respond in a timely manner. As per Python Requests doc (http://docs.python-requests.org/en/latest/user/advanced/#timeouts), 
"It’s a good practice to set connect timeouts to slightly larger than a multiple of 3, which is the default TCP packet retransmission window."

So that is what I did here, added a timeout a bit larger than a multiple of 3. 17 may be a bit large, we can discuss that if you wish so, we can play with the connect and read timeouts separately.

Since Python threads API do not have the ability to kill a thread, when running pybikes in a threaded environment, if one of the thread's request hangs, the pool will never join and everything gets stuck.
