### PR TITLE
[Base] Changing the default BikeSharingStation constructor

### DIFF
--- a/pybikes/base.py
+++ b/pybikes/base.py
@@ -26,6 +26,8 @@ class BikeShareStation(object):
 
     def __init__(self, name = None, latitude = None, longitude = None,
                        bikes = None, free = None, extra = None):
+        if extra is None:
+            extra = {}
         self.name = name
         self.latitude = latitude
         self.longitude = longitude

--- a/pybikes/base.py
+++ b/pybikes/base.py
@@ -26,15 +26,13 @@ class BikeShareStation(object):
 
     def __init__(self, name = None, latitude = None, longitude = None,
                        bikes = None, free = None, extra = None):
-        if extra is None:
-            extra = {}
         self.name = name
         self.latitude = latitude
         self.longitude = longitude
         self.bikes = bikes
         self.free = free
         self.timestamp = datetime.utcnow()     # Store timestamp in UTC!
-        self.extra = extra
+        self.extra = extra or {}
 
     def __str__(self):
         return "--- {0} ---\n"\

--- a/pybikes/base.py
+++ b/pybikes/base.py
@@ -24,17 +24,15 @@ class BikeShareStation(object):
             - JCDecauxStation, ClearChannelStation
     """
 
-    def __init__(self, id = 0, timestamp = None):
-        if timestamp is None:
-            timestamp = datetime.utcnow()
-
-        self.name = None
-        self.latitude = None
-        self.longitude = None
-        self.bikes = None
-        self.free = None
-        self.timestamp = timestamp     # Store timestamp in UTC!
-        self.extra = {}
+    def __init__(self, name = None, latitude = None, longitude = None,
+                       bikes = None, free = None, extra = {}):
+        self.name = name
+        self.latitude = latitude
+        self.longitude = longitude
+        self.bikes = bikes
+        self.free = free
+        self.timestamp = datetime.utcnow()     # Store timestamp in UTC!
+        self.extra = extra
 
     def __str__(self):
         return "--- {0} ---\n"\

--- a/pybikes/base.py
+++ b/pybikes/base.py
@@ -25,7 +25,7 @@ class BikeShareStation(object):
     """
 
     def __init__(self, name = None, latitude = None, longitude = None,
-                       bikes = None, free = None, extra = {}):
+                       bikes = None, free = None, extra = None):
         self.name = name
         self.latitude = latitude
         self.longitude = longitude

--- a/pybikes/ciclosampa.py
+++ b/pybikes/ciclosampa.py
@@ -46,7 +46,7 @@ class CicloSampaStation(BikeShareStation):
             [latitude, longitude, stationId, name, address, availableBikes,
              bike capacity]
         '''
-        super(CicloSampaStation, self).__init__(0)
+        super(CicloSampaStation, self).__init__()
         self.name = data[3]
         self.latitude = float(data[0])
         self.longitude = float(data[1])

--- a/pybikes/keolis.py
+++ b/pybikes/keolis.py
@@ -74,7 +74,7 @@ class KeolisStation(BikeShareStation):
             </div>
         </div>
         """
-        super(KeolisStation, self).__init__(0)
+        super(KeolisStation, self).__init__()
         fuzzle = lxml.html.fromstring(
             data[2].encode('utf8').decode('string-escape')
         )
@@ -129,13 +129,13 @@ class Keolis_v2(BikeShareSystem):
 
         stations = []
         for index, marker in enumerate(xml_list.iter('marker')):
-            station = KeolisStation_v2(index, marker, self.station_url)
+            station = KeolisStation_v2(marker, self.station_url)
             stations.append(station)
         self.stations = stations
 
 class KeolisStation_v2(BikeShareStation):
-    def __init__(self, index, marker, station_url):
-        super(KeolisStation_v2, self).__init__(index)
+    def __init__(self, marker, station_url):
+        super(KeolisStation_v2, self).__init__()
 
         self.name      = marker.get('name')
         self.latitude  = float(marker.get('lat'))

--- a/pybikes/nextbike.py
+++ b/pybikes/nextbike.py
@@ -50,7 +50,7 @@ class NextbikeStation(BikeShareStation):
         return super(NextbikeStation, cls).__new__(cls, place_tree)
 
     def __init__(self, place_tree):
-        super(NextbikeStation, self).__init__(0)
+        super(NextbikeStation, self).__init__()
         self.extra = {}
 
         # Some names are '1231-foo' and other are 'bar'

--- a/pybikes/smartbike.py
+++ b/pybikes/smartbike.py
@@ -69,7 +69,7 @@ def get_json_v2_stations(self, raw):
 
 class SmartBikeStation(BikeShareStation):
     def __init__(self, info):
-        super(SmartBikeStation, self).__init__(0)
+        super(SmartBikeStation, self).__init__()
         try:
             self.name = info['StationName']
             self.bikes = int(info['StationAvailableBikes'])


### PR DESCRIPTION
As discussed in #77, the addition of name, lat, lng, bikes, free and extra to the constructor of the BikeSharingStation.

However, the following system classes:

```python
super(SmartBikeStation, self).__init__(0)
super(NextbikeStation, self).__init__(0)
super(CicloSampaStation, self).__init__(0)
super(KeolisStation, self).__init__(0)
super(KeolisStation_v2, self).__init__(index)
```
passed `0` (or `index`) as the `id` parameter. What is this `id` parameter for, that I could not find?

Also, I've cleaned up the `datetime`, as it is never used, I've attributed it directly, instead of checking if it was `None`.

Consequently, I've changed those classes accordingly to remove the attribute.  

Let me know what you think. We can work more on that.