### PR TITLE
Changing GB to ISO_3166-2:GB relative codes

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -262,7 +262,7 @@
                         "city": "Bath",
                         "name": "Bike in Bath",
                         "longitude": -2.362404,
-                        "country": "GB"
+                        "country": "GB-ENG"
                     },
                     "tag": "bike-in-bath",
                     "endpoint": "http://www.bikeinbath.com/frmLeStazioni.aspx"

--- a/pybikes/data/bixi.json
+++ b/pybikes/data/bixi.json
@@ -33,7 +33,7 @@
             "meta": {
                 "city": "London", 
                 "name": "Santander Cycles", 
-                "country": "GB", 
+                "country": "GB-ENG", 
                 "company": [
                     "PBSC", 
                     "Serco Group plc"

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -709,7 +709,7 @@
                 "city": "Belfast",
                 "name": "BelfastBikes",
                 "longitude": -5.92918,
-                "country": "GB"
+                "country": "GB-NIR"
             },
             "city_uid": "238"
         },

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -686,7 +686,7 @@
                 "latitude": 51.382,
                 "city": "Bath",
                 "longitude": -2.36275,
-                "country": "GB"
+                "country": "GB-ENG"
             },
             "city_uid": "236"
         },
@@ -697,7 +697,7 @@
                 "latitude": 55.8589,
                 "city": "Glasgow",
                 "longitude": -4.25549,
-                "country": "GB"
+                "country": "GB-SCT"
             },
             "city_uid": "237"
         },

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -731,7 +731,7 @@
                 "latitude": 56.1165,
                 "city": "Stirling",
                 "longitude": -3.9369,
-                "country": "GB"
+                "country": "GB-SCT"
             },
             "city_uid": "243"
         },


### PR DESCRIPTION
Scotland, and England are countries and have their own ISO_3166 codes, which are described here: https://en.wikipedia.org/wiki/ISO_3166-2:GB

This PR changes the "country" attribute of those countries accordingly.
