### PR TITLE
Add bikes from Brescia

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -324,6 +324,17 @@
                 },
                 {
                     "meta": {
+                        "latitude": 45.5398382,
+                        "city": "Brescia",
+                        "name": "BiciMia",
+                        "longitude": 10.2229562,
+                        "country": "IT"
+                    },
+                    "endpoint": "https://bicimia.bresciamobilita.it/frmLeStazioni.aspx",
+                    "tag": "bicimia"
+                },
+                {
+                    "meta": {
                         "latitude": 41.833502,
                         "city": "Ischitella – Peschici – Rodi Garganico – Vico del Gargano",
                         "name": "Parkinbici",


### PR DESCRIPTION
Just a small change in order to add support for Brescia bike-sharing system, called "BiciMia". 

This bike-sharing system is based on "bicincitta".

Homepage of BiciMia: https://bicimia.bresciamobilita.it/Default.aspx

Stations page of BiciMia: https://bicimia.bresciamobilita.it/frmLeStazioni.aspx