### PR TITLE
Update Helsinki name

### DIFF
--- a/pybikes/data/smoove.json
+++ b/pybikes/data/smoove.json
@@ -7,14 +7,15 @@
                     "tag":"citybikefinland-hsk",
                     "meta":{
                         "city":"Helsinki",
-                        "name":"CityBikeFinland",
+                        "name":"City bikes",
                         "country":"FI",
                         "company":[
                             "Helsinki City Transport",
-                            "Helsinki Regional Transport Authority",
+                            "Helsinki Regional Transport",
                             "CityBikeFinland",
                             "Smoove SAS",
-                            "Moventia"
+                            "Moventia",
+                            "Alepa"
                         ],
                         "longitude":24.938379,
                         "latitude":60.16985569999999


### PR DESCRIPTION
I've not seen the scheme called CityBikeFinland anywhere, they're just called "city bikes" or "Helsinki city bikes" in English:
https://www.hsl.fi/en/citybikes

Also add the sponsoring company.

Re: https://github.com/eskerda/pybikes/issues/128#issuecomment-216623189