### PR TITLE
Removed Cantu - Biciamo

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -936,17 +936,6 @@
                     }
                 },
                 {
-                    "tag": "biciamo",
-                    "system_id": 65,
-                    "meta": {
-                        "name": "BICIamo",
-                        "city": "Cantù",
-                        "country": "IT",
-                        "latitude": 45.73626,
-                        "longitude": 9.12569
-                    }
-                },
-                {
                     "tag": "casalmaggiore",
                     "system_id": 40,
                     "meta": {


### PR DESCRIPTION
This fixes the issue of all the bicycles returned for Biciamo network being in Cagliaro, not in Cantu.

[`id: 65`](http://www.bicincitta.com/citta_v3.asp?id=65&pag=2) is for Cagliari and not for Cantu, and that data is a subset of what's available [via the existing Cagliari](http://bicincitta.tobike.it/frmLeStazioni.aspx?ID=177) entry.

I couldn't find new data for Cantu, so I propose to remove it.