### PR TITLE
Add Hourbike (Reading, Liverpool, Liconln, Sheffield) #148

### DIFF
--- a/pybikes/data/hourbike.json
+++ b/pybikes/data/hourbike.json
@@ -1,0 +1,50 @@
+{
+    "instances": [
+        {
+            "tag": "readybike",
+            "feed_url": "https://www.readybike.co.uk/map-of-stations.html",
+            "meta": {
+                "latitude": 51.434332,
+                "longitude": -0.96866,
+                "city": "Reading",
+                "name": "Readybike",
+                "country": "GB"
+            }
+        },
+        {
+            "tag": "citybike-liverpool",
+            "feed_url": "https://www.citybikeliverpool.co.uk/map-of-stations.html",
+            "meta": {
+                "latitude": 53.358322,
+                "longitude": -2.864017,
+                "city": "Liverpool",
+                "name": "Citybike Liverpool",
+                "country": "GB"
+            }
+        },
+        {
+            "tag": "hirebike",
+            "feed_url": "https://www.hirebikelincoln.co.uk/map-of-stations.html",
+            "meta": {
+                "latitude": 53.2145628869,
+                "longitude": -0.603208756027,
+                "city": "Lincoln",
+                "name": "Hirebike",
+                "country": "GB"
+            }
+        },
+        {
+            "tag": "sheffieldbycycle",
+            "feed_url": "https://www.sheffieldbicycle.co.uk/map-of-stations.html",
+            "meta": {
+                "latitude": 53.2145628869,
+                "longitude": -0.603208756027,
+                "city": "Sheffield",
+                "name": "Sheffield By Cycle",
+                "country": "GB"
+            }
+        }
+    ],
+    "system": "hourbike",
+    "class": "Hourbike"
+}

--- a/pybikes/hourbike.py
+++ b/pybikes/hourbike.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>
+# Distributed under the AGPL license, see LICENSE.txt
+
+import re
+import json
+
+from .base import BikeShareSystem, BikeShareStation
+from . import utils
+
+__all__ = ['Hourbike']
+
+RGX_MARKERS = r'Operator\.StationsData = (.*?)\;'
+
+class Hourbike(BikeShareSystem):
+
+    meta = {
+        'system': 'Hourbike',
+        'company': 'Hourbike'
+    }
+
+    def __init__(self, tag, feed_url, meta):
+        super(Hourbike, self).__init__(tag, meta)
+        self.feed_url = feed_url
+
+    def update(self, scraper=None):
+        if scraper is None:
+            scraper = utils.PyBikesScraper()
+
+        self.stations = []
+        html = scraper.request(self.feed_url)
+
+        raw_data = re.search(RGX_MARKERS, html).group(1)
+        stations_data = json.loads(raw_data)
+
+        for station in stations_data:
+            latitude = float(station['Latitude'])
+            longitude = float(station['Longitude'])
+
+            name = station['Name']
+            bikes = int(station['TotalAvailableBikes'])
+            free = int(station['TotalLocks']) - bikes
+            extra = {
+                'uid': station['id']
+            }
+            station = BikeShareStation(name, latitude, longitude, bikes, free,
+                                       extra)
+            self.stations.append(station)

--- a/pybikes/hourbike.py
+++ b/pybikes/hourbike.py
@@ -10,7 +10,7 @@ from . import utils
 
 __all__ = ['Hourbike']
 
-RGX_MARKERS = r'Operator\.StationsData = (.*?)\;'
+RGX_MARKERS = r'setConfig\(\'StationsData\',(\[.*\])\);'
 
 class Hourbike(BikeShareSystem):
 


### PR DESCRIPTION
In response to #148. It is important to know, though, that the Hourbike system uses the same BikeU system for two cities: Oxford (Oxonbikes) and Northampton (Cycle Connect):
- [Oxonbikes](https://www.oxonbikes.co.uk/map-of-stations.html)
- [Cycle Connect](https://www.cycleconnect.co.uk/map-of-stations.html)

As the systems (Hourbike and BikeU) are managed by different entities, I think the correct approach here is to replicate the code from BikeU inside Hourbike (using a second class, e.g., HourbikeAlternative). That would be better than the obvious merging of Hourbike cities into BikeU and replicating this code here inside BikeU. I suggest that because if one of those companies change the system, we are screwed and will have to split the code again.

@eskerda, WDYT?
