### PR TITLE
[smartbike] Add "Malmö by bike" from Malmö, SE

### DIFF
--- a/pybikes/data/smartbike.json
+++ b/pybikes/data/smartbike.json
@@ -65,6 +65,18 @@
                     },
                     "feed_url": "https://www.velo-antwerpen.be/availability_map/getJsonObject",
                     "format": "json_v2"
+                },
+                {
+                    "tag": "malmobybike",
+                    "meta": {
+                        "latitude": 55.6050,
+                        "city": "Malm\u00f6",
+                        "name": "Malm\u00f6 by bike",
+                        "longitude": 13.0038,
+                        "country": "SE"
+                    },
+                    "feed_url": "https://www.malmobybike.se/availability_map/getJsonObject",
+                    "format": "json_v2"
                 }
             ]
         }

--- a/pybikes/smartbike.py
+++ b/pybikes/smartbike.py
@@ -89,18 +89,19 @@ class SmartBikeStation(BikeShareStation):
             self.longitude = float(info['lon'])
             self.extra = {
                 'uid': int(info['id']),
-                'status': info['status'],
-                'address': info['address']
+                'status': info['status']
             }
-
+            if 'address' in info:
+                self.extra['address'] = info['address']
             if 'district' in info:
                 self.extra['districtCode'] = info['district']
             elif 'districtCode' in info:
                 self.extra['districtCode'] = info['districtCode']
 
-            if info['nearbyStations'] and info['nearbyStations'] != "0":
+            nearby_stations = info.get('nearbyStations')
+            if nearby_stations and nearby_stations != "0":
                 self.extra['NearbyStationList'] = map(
-                    int, info['nearbyStations'].split(',')
+                    int, nearby_stations.split(',')
                 )
 
             if 'zip' in info and info['zip']:


### PR DESCRIPTION
Malmö by bike <https://www.malmobybike.se/en> is a bike rental system in
Malmö (Sweden) operated by Clear Channel.

Since some stations do not contain 'address' and/or 'nearbyStations',
the class SmartBike was changed to cope with the missing fields and avoid
throwing errors.

P.S.: I don't have experience with Python, so apologies if my changes are not idiomatic.