### PR TITLE
Rename tag for barclays-cycle-hire

### DIFF
--- a/pybikes/data/bixi.json
+++ b/pybikes/data/bixi.json
@@ -29,7 +29,7 @@
             "format": "xml"
         }, 
         {
-            "tag": "barclays-cycle-hire", 
+            "tag": "santander-cycles", 
             "meta": {
                 "city": "London", 
                 "name": "Santander Cycles", 


### PR DESCRIPTION
Now named santander-cycles.. Well, in fact it's been like that for a while