### PR TITLE
List install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Or after downloading/cloning the source:
 ```bash
 python setup.py install
 ```
+
+The following dependencies are required (example using Ubuntu package manager):
+```
+sudo apt-get install python
+sudo apt-get install python-setuptools
+sudo apt-get install libxml2 libxml2-dev libxslt1-dev
+```
+
+
 Usage
 -----
 ```python


### PR DESCRIPTION
This commit adds the required install dependencies to the readme, giving an example set of commands (for Ubuntu, but will be understandable by sysadmins for other systems).