### PR TITLE
[Smoove] Removing Reflex, service is over

### DIFF
--- a/pybikes/data/smoove.json
+++ b/pybikes/data/smoove.json
@@ -40,17 +40,6 @@
                     "feed_url":"http://www.velopop.fr/stations.html"
                 },
                 {
-                    "tag":"reflex-grandchalon",
-                    "meta":{
-                        "latitude":46.819904,
-                        "city":"Chalon-sur-Sa\u00f4ne",
-                        "name":"R\u00e9flex",
-                        "longitude":4.837021,
-                        "country":"FR"
-                    },
-                    "feed_url":"http://www.reflex-grandchalon.fr/sag_vls_stations.html"
-                },
-                {
                     "tag":"libelo",
                     "meta":{
                         "latitude":44.922726,


### PR DESCRIPTION
Service was supressed September 2015. You can read more info [here](http://france3-regions.francetvinfo.fr/bourgogne/saone-et-loire/chalon-sur-saone/saone-et-loire-pourquoi-chalon-range-ses-velos-reflex-au-garage-760686.html) (in French)