### PR TITLE
Call superclass' __init__

### DIFF
--- a/pybikes/cleanap.py
+++ b/pybikes/cleanap.py
@@ -30,6 +30,7 @@ class Cleanap(BikeShareSystem):
 
 class CleanapStation(BikeShareStation):
     def __init__(self, data):
+        super(CleanapStation, self).__init__()
         self.name = data['title']
         self.latitude = float(data['latitude'])
         self.longitude = float(data['longitude'])


### PR DESCRIPTION
`CleanapStation` is missing a call to its `BikeShareStation`'s `__init__` to set default values.