### PR TITLE
[velobike-ru] Remove station ID from address extra field

### DIFF
--- a/pybikes/velobike_ru.py
+++ b/pybikes/velobike_ru.py
@@ -46,7 +46,7 @@ class VelobikeRU(BikeShareSystem):
             extra = {
                 'uid': item['Id'],
                 'slots': int(item['TotalPlaces']),
-                'address': item['Address'],
+                'address': item['Address'].split("- ", 1)[1],
             }
             station = BikeShareStation(name, latitude, longitude, bikes, free,
                                        extra)

--- a/pybikes/velobike_ru.py
+++ b/pybikes/velobike_ru.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import re
 
 from .base import BikeShareSystem, BikeShareStation
 from . import utils
@@ -46,7 +47,7 @@ class VelobikeRU(BikeShareSystem):
             extra = {
                 'uid': item['Id'],
                 'slots': int(item['TotalPlaces']),
-                'address': item['Address'].split("- ", 1)[1],
+                'address': re.sub(r'^\d+\s*-\s*', '', item['Address'])
             }
             station = BikeShareStation(name, latitude, longitude, bikes, free,
                                        extra)


### PR DESCRIPTION
Station name is e.g. `466 - Продольный пр-д (у главного входа ВДНХ)`, but the address field should not include the station ID at the start.