### PR TITLE
Remove nextbike feeds

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -321,17 +321,6 @@
         },
         {
             "domain": "de",
-            "tag": "nextbike-bielefeld",
-            "meta": {
-                "latitude": 52.0257,
-                "city": "Bielefeld",
-                "longitude": 8.53286,
-                "country": "DE"
-            },
-            "city_uid": "16"
-        },
-        {
-            "domain": "de",
             "tag": "nextbike-gutersloh",
             "meta": {
                 "latitude": 51.9049,

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -1219,18 +1219,6 @@
             "city_uid": 342
         },
         {
-            "domain": "hg",
-            "tag": "heraeus-hanau",
-            "meta": {
-                "name": "Heraeus Hanau",
-                "latitude": 50.133333,
-                "longitude": 8.916667,
-                "city": "Hanau",
-                "country": "DE"
-            },
-            "city_uid": 301
-        },
-        {
             "domain": "lp",
             "tag": "lodzki-rower-publiczny",
             "meta": {


### PR DESCRIPTION
* Remove Bielefeld (http://www.nextbike.de/en/bielefeld/)
* Remove Hanau (feed no longer exists)

@BenSto Since you added Hanau, do you know what happened? I cannot find it on nextbike website at all, 'hg' domain no longer exists and it's not on the 'de' domain nor on their map. I wonder if this means they have closed for the season?