### PR TITLE
Add missing minus sign to Tampa longitude

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -273,7 +273,7 @@
             "tag": "coast-bike-share",
             "meta": {
                 "latitude": 27.9627193250593,
-                "longitude": 82.438056400783,
+                "longitude": -82.438056400783,
                 "city": "Tampa, FL",
                 "name": "Coast Bike Share",
                 "country": "US",


### PR DESCRIPTION
Otherwise the coordinates point to a place in Nepal instead of Tampa, FL. Feel free to have a look and merge into master if you agree that Tampa, FL is not in Nepal ;-) . :bike:  :bike:  :grinning: 