### PR TITLE
[Samba] Sorocaba is over within Mobilicidade system

### DIFF
--- a/pybikes/data/samba.json
+++ b/pybikes/data/samba.json
@@ -48,17 +48,6 @@
                     }
                 },
                 {
-                    "url":"http://ww2.mobilicidade.com.br/sorocaba/mapaestacao.asp",
-                    "tag":"bikesorocaba",
-                    "meta":{
-                        "latitude":-23.501719,
-                        "city":"Sorocaba",
-                        "name":"BikeSorocaba",
-                        "longitude":-47.45079,
-                        "country":"BR"
-                    }
-                },
-                {
                     "url":"http://ww2.mobilicidade.com.br/petrobike/mapaestacao.asp",
                     "tag":"bikepetrolina",
                     "meta":{


### PR DESCRIPTION
Sorocaba's system is not on Mobilicidade's anymore, it was improved and went to CompartiBike, refer to #213.