### PR TITLE
Adding libgeos-dev to the README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following dependencies are required (example using Ubuntu package manager):
 ```
 sudo apt-get install python
 sudo apt-get install python-setuptools
-sudo apt-get install libxml2 libxml2-dev libxslt1-dev
+sudo apt-get install libxml2 libxml2-dev libxslt1-dev libgeos-dev
 ```
 
 


### PR DESCRIPTION
Hi,

I'm using Ubuntu 16.10 and I have needed to install `libgeos-dev` in order to start using `pybikes`.

I thought it is worth to add it to the readme to help others.