### PR TITLE
GBFS: Remove coast bikeshare

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -270,21 +270,6 @@
             "feed_url": "https://gbfs.citibikenyc.com/gbfs/gbfs.json"
         },
         {
-            "tag": "coast-bike-share",
-            "meta": {
-                "latitude": 27.9627193250593,
-                "longitude": -82.438056400783,
-                "city": "Tampa, FL",
-                "name": "Coast Bike Share",
-                "country": "US",
-                "company": [
-                    "CycleHop, LLC",
-                    "Social Bicycles Inc."
-                ]
-            },
-            "feed_url": "https://coast.socialbicycles.com/opendata/gbfs.json"
-        },
-        {
             "tag": "cogo",
             "meta": {
                 "latitude": 39.983333,


### PR DESCRIPTION
It is gone from GBFS.