### PR TITLE
GBFS: Pronto Cycle Share ceased operations on March 31, 2017

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -554,22 +554,6 @@
             "feed_url": "https://api-core.niceridemn.org/gbfs/gbfs.json"
         },
         {
-            "tag": "pronto-cycle-share",
-            "meta": {
-                "latitude": 47.606209,
-                "longitude": -122.332071,
-                "city": "Seattle, WA",
-                "name": "Pronto Cycle Share",
-                "country": "US",
-                "company": [
-                    "Pronto!",
-                    "City of Seattle",
-                    "Motivate International, Inc."
-                ]
-            },
-            "feed_url": "https://gbfs.prontocycleshare.com/gbfs/gbfs.json"
-        },
-        {
             "tag": "sanantonio",
             "meta": {
                 "latitude": 29.43701,


### PR DESCRIPTION
As shown in the news and already displayed in [their](https://www.prontocycleshare.com/) site.