### PR TITLE
Add warning about correct Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ sudo apt-get install python-setuptools
 sudo apt-get install libxml2 libxml2-dev libxslt1-dev libgeos-dev
 ```
 
+### Important
+
+Make sure to use Python 2 and not Python 3 when installing or using pybikes!
+When installing via `pip`, make sure you are not using a version of `pip` bundled with Python 3!
+
 
 Usage
 -----


### PR DESCRIPTION
This should prevent programmers not familiar with the Python ecosystem from losing half an hour before they can contribute their bike sharing systems to the project.