### PR TITLE
Added Reykjavík Wow Citybike

### DIFF
--- a/pybikes/data/bixi.json
+++ b/pybikes/data/bixi.json
@@ -1,65 +1,65 @@
 {
     "instances": [
         {
-            "tag": "bixi-montreal", 
+            "tag": "bixi-montreal",
             "meta": {
-                "latitude": 45.5086699, 
-                "city": "Montreal, QC", 
-                "name": "Bixi", 
-                "longitude": -73.55399249999999, 
+                "latitude": 45.5086699,
+                "city": "Montreal, QC",
+                "name": "Bixi",
+                "longitude": -73.55399249999999,
                 "country": "CA"
-            }, 
-            "feed_url": "https://montreal.bixi.com/data/bikeStations.xml", 
+            },
+            "feed_url": "https://montreal.bixi.com/data/bikeStations.xml",
             "format": "xml"
-        }, 
+        },
         {
-            "tag": "santander-cycles", 
+            "tag": "santander-cycles",
             "meta": {
-                "city": "London", 
-                "name": "Santander Cycles", 
-                "country": "GB", 
+                "city": "London",
+                "name": "Santander Cycles",
+                "country": "GB",
                 "company": [
-                    "PBSC", 
+                    "PBSC",
                     "Serco Group plc"
-                ], 
-                "longitude": -0.1198244, 
+                ],
+                "longitude": -0.1198244,
                 "latitude": 51.51121389999999
-            }, 
-            "feed_url": "http://www.tfl.gov.uk/tfl/syndication/feeds/cycle-hire/livecyclehireupdates.xml", 
+            },
+            "feed_url": "http://www.tfl.gov.uk/tfl/syndication/feeds/cycle-hire/livecyclehireupdates.xml",
             "format": "xml"
-        }, 
+        },
         {
-            "tag": "bike-chattanooga", 
+            "tag": "bike-chattanooga",
             "meta": {
-                "city": "Chattanooga, TN", 
-                "name": "Bike Chattanooga", 
-                "country": "US", 
+                "city": "Chattanooga, TN",
+                "name": "Bike Chattanooga",
+                "country": "US",
                 "company": [
-                    "PBSC", 
+                    "PBSC",
                     "Alta Bicycle Share, Inc"
-                ], 
-                "longitude": -85.3096801, 
+                ],
+                "longitude": -85.3096801,
                 "latitude": 35.0456297
-            }, 
-            "feed_url": "http://www.bikechattanooga.com/stations/json", 
+            },
+            "feed_url": "http://www.bikechattanooga.com/stations/json",
             "format": "json"
-        }, 
+        },
         {
-            "tag": "melbourne-bike-share", 
+            "tag": "melbourne-bike-share",
             "meta": {
-                "city": "Melbourne", 
-                "name": "Melbourne Bike Share", 
-                "country": "AU", 
+                "city": "Melbourne",
+                "name": "Melbourne Bike Share",
+                "country": "AU",
                 "company": [
-                    "PBSC", 
+                    "PBSC",
                     "Alta Bicycle Share, Inc"
-                ], 
-                "longitude": 144.96328, 
+                ],
+                "longitude": 144.96328,
                 "latitude": -37.814107
-            }, 
-            "feed_url": "http://www.melbournebikeshare.com.au/stationmap/data", 
+            },
+            "feed_url": "http://www.melbournebikeshare.com.au/stationmap/data",
             "format": "json_from_xml"
-        }, 
+        },
         {
             "tag": "we-cycle",
             "meta": {
@@ -75,8 +75,24 @@
             },
             "feed_url": "https://www.we-cycle.org/pbsc/stations.php",
             "format": "json"
+        },
+        {
+            "tag": "wowcycle-reykjavik",
+            "meta": {
+                "city": "Reykjavík",
+                "name": "WOW Citybike",
+                "country": "IS",
+                "company": [
+                    "PBSC",
+                    "Alta Bicycle Share, Inc"
+                ],
+                "longitude": -21.827774,
+                "latitude": 64.128288
+            },
+            "feed_url": "https://rey.publicbikesystem.net/ube/stations",
+            "format": "json"
         }
-    ], 
-    "system": "bixi", 
+    ],
+    "system": "bixi",
     "class": "BixiSystem"
 }


### PR DESCRIPTION
The Icelandic airline WOW just launched, in co-operation with PBSC, a system in Reykjavík, Iceland. It has 8 stations and 100 bikes.

Webpage: https://wowcitybike.com/

This adds that to the bixi.json file.

Tests:

[...]
```
Testing u'Bike Chattanooga', u'Chattanooga, TN'
Bike Chattanooga has 37 stations
↑ stations look ok ↑

Testing u'WOW Citybike', u'Reykjav\xedk'
WOW Citybike has 8 stations
↑ stations look ok ↑

Testing u'Melbourne Bike Share', u'Melbourne'
Melbourne Bike Share has 50 stations
↑ stations look ok ↑
[...]
```

Usage:
```
>>> import pybikes
>>> rey_bikes = pybikes.get('wowcycle-reykjavik')
>>> print rey_bikes
tag: wowcycle-reykjavik
meta: {'city': u'Reykjav\xedk', 'name': u'WOW Citybike', 'country': u'IS', 'company': [u'PBSC', u'Alta Bicycle Share, Inc'], 'system': 'Bixi', 'longitude': -21.827774, 'latitude': 64.128288}
>>> print rey_bikes.stations
[]
>>> rey_bikes.update()
>>> print rey_bikes.stations
[<pybikes.bixi.BixiStation object at 0x11064a750>, <pybikes.bixi.BixiStation object at 0x11064a6d0>, <pybikes.bixi.BixiStation object at 0x11064a710>, <pybikes.bixi.BixiStation object at 0x11065a550>, <pybikes.bixi.BixiStation object at 0x11065a6d0>, <pybikes.bixi.BixiStation object at 0x11065a710>, <pybikes.bixi.BixiStation object at 0x11065a750>, <pybikes.bixi.BixiStation object at 0x11065a790>]
>>> print rey_bikes.stations[0]
--- u'1 - L\xe6kjartorg Square' ---
bikes: 15
free: 8
latlng: 64.1477,-21.9362
extra: {'uid': 1, 'landMark': u'', 'lastCommunicationTime': u'2017-06-19 20:00:56', 'city': u'Reykjavik', 'totalDocks': 23, 'altitude': u'', 'stAddress2': u'', 'stAddress1': u'L\xe6kjartorg Square', 'statusValue': u'In Service', 'testStation': False, 'location': u'', 'postalCode': u'', 'statusKey': 1}
>>> rey_bikes.update()
>>> print rey_bikes.stations[0]
--- u'1 - L\xe6kjartorg Square' ---
bikes: 15
free: 8
latlng: 64.1477,-21.9362
extra: {'uid': 1, 'landMark': u'', 'lastCommunicationTime': u'2017-06-19 20:05:18', 'city': u'Reykjavik', 'totalDocks': 23, 'altitude': u'', 'stAddress2': u'', 'stAddress1': u'L\xe6kjartorg Square', 'statusValue': u'In Service', 'testStation': False, 'location': u'', 'postalCode': u'', 'statusKey': 1}
```