### PR TITLE
Update country code to match other GB bike shares

### DIFF
--- a/pybikes/data/cyclehire.json
+++ b/pybikes/data/cyclehire.json
@@ -7,7 +7,7 @@
                 "longitude": -0.591562,
                 "city": "Slough",
                 "name": "Cycle Hire",
-                "country": "UK",
+                "country": "GB",
                 "company": [
                     "Groundwork",
                     "Slough Borough Council",


### PR DESCRIPTION
Slough Borough Council is the only bike share to
use UK as the country code (Ref issue #270). The other United Kingdom
bike shares appear to use GB. Change only changes country code.