### PR TITLE
Switch Bike Bike Chattanooga to use GBFS

### DIFF
--- a/pybikes/data/bixi.json
+++ b/pybikes/data/bixi.json
@@ -29,22 +29,6 @@
             "format": "xml"
         },
         {
-            "tag": "bike-chattanooga",
-            "meta": {
-                "city": "Chattanooga, TN",
-                "name": "Bike Chattanooga",
-                "country": "US",
-                "company": [
-                    "PBSC",
-                    "Alta Bicycle Share, Inc"
-                ],
-                "longitude": -85.3096801,
-                "latitude": 35.0456297
-            },
-            "feed_url": "http://www.bikechattanooga.com/stations/json",
-            "format": "json"
-        },
-        {
             "tag": "melbourne-bike-share",
             "meta": {
                 "city": "Melbourne",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -101,6 +101,21 @@
             "feed_url": "https://gbfs.bcycle.com/bcycle_austin/gbfs.json"
         },
         {
+            "tag": "bike-chattanooga",
+            "meta": {
+                "longitude": -85.3096801,
+                "latitude": 35.0456297,
+                "city": "Chattanooga, TN",
+                "name": "Bike Chattanooga",
+                "country": "US",
+                "company": [
+                    "Motivate International, Inc",
+                    "PBSC"
+                ]
+            },
+            "feed_url": "https://gbfs.bikechattanooga.com/gbfs/gbfs.json"
+        },
+        {
             "tag": "biketown",
             "meta": {
                 "latitude": 45.52175423291714,


### PR DESCRIPTION
Bike Chattanooga supports GBFS, a [standard developed by NABSA](https://github.com/NABSA/gbfs/blob/master/systems.csv), and should be used as the source for bike share information for the system.

The company has also been changed to `Motivate International, Inc`, which replaced Alta and [now operates the system](https://www.motivateco.com/where-we-do-it/chattanooga-tn/).