### PR TITLE
Fixes to bcycle and smoove

### DIFF
--- a/pybikes/bcycle.py
+++ b/pybikes/bcycle.py
@@ -91,7 +91,7 @@ class BCycleStation(BikeShareStation):
             bikes, free = dom.xpath("//div[@class='avail']/strong/text()")
 
         except ValueError:
-            name, = dom.xpath("//div[@class='markerTitle']/h3/text()")
+            name, = dom.xpath("//div[@class='markerPublicText']/h5/text()")
 
             if name.lower() == 'purgatory':
                 raise BCyclePurgatoryException

--- a/pybikes/smoove.py
+++ b/pybikes/smoove.py
@@ -67,6 +67,9 @@ class SmooveAPI(Smoove):
         data = json.loads(scraper.request(self.feed_url))
         stations = []
         for s in data['result']:
+            # inoperative stations have 'coordinates': '', skip them
+            if s['coordinates'] == '':
+                continue
             lat, lng = map(float, s['coordinates'].split(','))
             name = s['name']
             bikes = int(s['avl_bikes'])


### PR DESCRIPTION
The xpath to the station name for bcycle has changed.
Smoove was having problem because some results had the coordinates as the empty string, causing the whole result to fail. The solution is to skip disabled stations