### PR TITLE
Add nextbike cardiff

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -1936,6 +1936,17 @@
                 "name": "MOL Bubi",
                 "country": "HU"
             }
+        },
+		{
+            "domain": "uk",
+            "tag": "nextbike-cardiff",
+            "city_uid": 476,
+            "meta": {
+                "city": "Cardiff",
+                "country": "GB",
+                "latitude": 51.4822,
+                "longitude": -3.18089
+            }
         }
     ],
     "system": "nextbike",

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -1937,8 +1937,8 @@
                 "country": "HU"
             }
         },
-		{
-            "domain": "uk",
+        {
+            "domain": "uc",
             "tag": "nextbike-cardiff",
             "city_uid": 476,
             "meta": {


### PR DESCRIPTION
Either the domain for the cardiff feed was wrong or it changed over time. This PR is based on https://github.com/eskerda/pybikes/pull/314 and fixes the domain code.

Thanks @ArwynHarris!