### PR TITLE
[nextbike] Check for empty bike_types attribute

### DIFF
--- a/pybikes/nextbike.py
+++ b/pybikes/nextbike.py
@@ -76,7 +76,7 @@ class NextbikeStation(BikeShareStation):
         # approximate to true, to signal that the number is not exact. Note
         # this is rather frequent case for 'bike_types' and infrequent
         # corner case for 'bikes' attribute.
-        if 'bike_types' in place.attrib:
+        if place.get('bike_types'):
             self.bikes = 0
             bike_types = json.loads(place.attrib['bike_types'])
             for value in bike_types.values():


### PR DESCRIPTION
This commit adds check for empty bike_types attribute. 

It's recently occurred for Nextbike Veturilo network that this attribute was in fact empty. This caused out-of-date api data.

Example: https://nextbike.net/maps/nextbike-live.xml?domains=vp&get_biketypes=1, uid `2585275`

edit: 
Currently the issue has disappeared. The station mentioned in the example returns `bike_types="{"4":4}"`, previously it was `bike_types=""`. This safeguard could turn out to be useful if such issue ever comes up, however.