### PR TITLE
[gbfs] Change San Antonio name

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -591,7 +591,7 @@
                 "latitude": 29.43701,
                 "longitude": -98.48236,
                 "city": "San Antonio, TX",
-                "name": "San Antonio B-cycle",
+                "name": "SWell Cycle",
                 "country": "US",
                 "company": ["BCycle, LLC"]
             },


### PR DESCRIPTION
San Antonio bike share system is called SWell Cycle, source [1]


[1]: https://sanantonio.bcycle.com/