### PR TITLE
Fix Melbourne Bike Share

### DIFF
--- a/pybikes/data/bixi.json
+++ b/pybikes/data/bixi.json
@@ -17,22 +17,6 @@
             "format": "xml"
         },
         {
-            "tag": "melbourne-bike-share",
-            "meta": {
-                "city": "Melbourne",
-                "name": "Melbourne Bike Share",
-                "country": "AU",
-                "company": [
-                    "PBSC",
-                    "Alta Bicycle Share, Inc"
-                ],
-                "longitude": 144.96328,
-                "latitude": -37.814107
-            },
-            "feed_url": "http://www.melbournebikeshare.com.au/stationmap/data",
-            "format": "json_from_xml"
-        },
-        {
             "tag": "we-cycle",
             "meta": {
                 "city": "Aspen, CO",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -817,7 +817,7 @@
               "longitude": 144.96328,
               "latitude": -37.814107
           },
-          "feed_url": "http://www.melbournebikeshare.com.au/stationmap/data",
+          "feed_url": "https://gbfs.melbourne.8d.com/gbfs/gbfs.json",
           "format": "json_from_xml"
         }
     ],

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -803,6 +803,22 @@
                 }
             },
             "feed_url": "http://gbfs.urbansharing.com/edinburghcyclehire/"
+        },
+        {
+          "tag": "melbourne-bike-share",
+          "meta": {
+              "city": "Melbourne",
+              "name": "Melbourne Bike Share",
+              "country": "AU",
+              "company": [
+                  "PBSC",
+                  "Alta Bicycle Share, Inc"
+              ],
+              "longitude": 144.96328,
+              "latitude": -37.814107
+          },
+          "feed_url": "http://www.melbournebikeshare.com.au/stationmap/data",
+          "format": "json_from_xml"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -817,8 +817,7 @@
               "longitude": 144.96328,
               "latitude": -37.814107
           },
-          "feed_url": "https://gbfs.melbourne.8d.com/gbfs/gbfs.json",
-          "format": "json_from_xml"
+          "feed_url": "https://gbfs.melbourne.8d.com/gbfs/gbfs.json"
         }
     ],
     "system": "gbfs",


### PR DESCRIPTION
The feed url and data format for Melbourne Bike Share seem to have changed, resulting in no data being scraped. I've moved it from `bixi.json` to `gbfs.json`, and updated the `feed-url` so it correctly pulls the data. 