### PR TITLE
Added Frelo Freiburg (to nextbike.json)

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -3040,7 +3040,7 @@
             "tag": "frelo-freiburg",
             "city_uid": 619,
             "meta": {
-                "name": "Frelo Freiburg",
+                "name": "Frelo",
                 "city": "Freiburg",
                 "country": "DE",
                 "latitude": 47.9958,

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -3034,6 +3034,18 @@
                 "latitude": 52.9952,
                 "longitude": 11.7517
             }
+        },
+        {
+            "domain": "df",
+            "tag": "frelo-freiburg",
+            "city_uid": 619,
+            "meta": {
+                "name": "Frelo Freiburg",
+                "city": "Freiburg",
+                "country": "DE",
+                "latitude": 47.9958,
+                "longitude": 7.84453
+            }
         }
     ],
     "system": "nextbike",


### PR DESCRIPTION
Frelo Freiburg, operated by nextbike, started this week.
www.frelo-freiburg.de

I hope this includes the system correctly. Please let me know if anything is missing.

Best,
Steffen