### PR TITLE
update feed url bike-chattanooga

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -129,7 +129,7 @@
                     "PBSC"
                 ]
             },
-            "feed_url": "https://gbfs.bikechattanooga.com/gbfs/gbfs.json"
+            "feed_url": "https://chat.publicbikesystem.net/ube/gbfs/v1/"
         },
         {
             "tag": "biketown",


### PR DESCRIPTION
new url for bike-chattanooga