### PR TITLE
Updates for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python:
     - "2.7"
+    - "3.7"
 install:
     # Disable gcc optimizations for greater install speed (lxml)
     - CFLAGS="-O0" pip install . --upgrade

--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -480,13 +480,7 @@ def _extractall(self, path=".", members=None):
         self.extract(tarinfo, path)
 
     # Reverse sort directories.
-    if sys.version_info < (2, 4):
-        def sorter(dir1, dir2):
-            return cmp(dir1.name, dir2.name)
-        directories.sort(sorter)
-        directories.reverse()
-    else:
-        directories.sort(key=operator.attrgetter('name'), reverse=True)
+    directories.sort(key=operator.attrgetter('name'), reverse=True)
 
     # Set correct owner, mtime and filemode on directories.
     for tarinfo in directories:
@@ -509,9 +503,6 @@ def _build_install_args(options):
     """
     install_args = []
     if options.user_install:
-        if sys.version_info < (2, 6):
-            log.warn("--user requires Python 2.6 or later")
-            raise SystemExit(1)
         install_args.append('--user')
     return install_args
 

--- a/pybikes/__init__.py
+++ b/pybikes/__init__.py
@@ -9,8 +9,20 @@ __license__ = "AGPL"
 
 import re
 import json
-from itertools import imap
 from pkg_resources import resource_string, resource_listdir
+try:
+    # Python 2
+    from itertools import imap as map
+except ImportError:
+    # Python 3
+    pass
+
+try:
+    # Python 2
+    basestring
+except NameError:
+    # Python 3
+    basestring = str
 
 from pybikes.exceptions import BikeShareSystemNotFound
 
@@ -42,7 +54,7 @@ def _uniclass_extractor(data):
 
 
 def _multiclass_extractor(data):
-    for k, v in data['class'].iteritems():
+    for k, v in data['class'].items():
         for i in data['class'][k]['instances']:
             yield (k, i)
 
@@ -84,7 +96,7 @@ def get_instance(schema, tag):
 
 
 def find_system(tag):
-    datas = imap(get_data, get_all_data())
+    datas = map(get_data, get_all_data())
     for data in datas:
         schema = data['system']
         try:

--- a/pybikes/__init__.py
+++ b/pybikes/__init__.py
@@ -17,13 +17,6 @@ except ImportError:
     # Python 3
     pass
 
-try:
-    # Python 2
-    basestring
-except NameError:
-    # Python 3
-    basestring = str
-
 from pybikes.exceptions import BikeShareSystemNotFound
 
 # Top class shortcuts
@@ -31,6 +24,14 @@ from pybikes.base import BikeShareSystem, BikeShareStation
 from pybikes.utils import PyBikesScraper
 from pybikes import utils
 from pybikes import contrib
+
+try:
+    # Python 2
+    basestring
+except NameError:
+    # Python 3
+    basestring = str
+
 
 def get_data(schema):
     name = re.sub(r'\.json$', '', schema)

--- a/pybikes/bicincitta.py
+++ b/pybikes/bicincitta.py
@@ -4,7 +4,12 @@
 
 import json
 
-from urlparse import urljoin
+try:
+    # Python 2
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
 

--- a/pybikes/bikeu.py
+++ b/pybikes/bikeu.py
@@ -3,7 +3,12 @@
 # Distributed under the AGPL license, see LICENSE.txt
 import re
 import json
-from urlparse import urljoin
+try:
+    # Python 2
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 from lxml import html
 

--- a/pybikes/cyclocity.py
+++ b/pybikes/cyclocity.py
@@ -2,9 +2,14 @@
 # Copyright (C) 2010-2012, eskerda <eskerda@gmail.com>
 # Distributed under the AGPL license, see LICENSE.txt
 
-import re
 import json
-import HTMLParser
+
+try:
+    # Python 2
+    from HTMLParser import HTMLParser
+except ImportError:
+    # Python 3
+    from html.parser import HTMLParser
 
 from lxml import etree
 
@@ -21,7 +26,7 @@ endpoints = {
     'station'  : 'stations/{station_id}?contract={contract}&apiKey={api_key}'
 }
 
-html_parser = HTMLParser.HTMLParser()
+html_parser = HTMLParser()
 
 class Cyclocity(BikeShareSystem):
 

--- a/pybikes/ecobici_ba.py
+++ b/pybikes/ecobici_ba.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from urlparse import urljoin
+try:
+    # Python 2
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 from pybikes.gbfs import Gbfs
 from pybikes.utils import PyBikesScraper

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -3,7 +3,12 @@
 # Distributed under the AGPL license, see LICENSE.txt
 
 import json
-from urlparse import urljoin
+try:
+    # Python 2
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 from pybikes import BikeShareSystem, BikeShareStation, exceptions
 from pybikes.utils import PyBikesScraper

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -13,6 +13,13 @@ except ImportError:
 from pybikes import BikeShareSystem, BikeShareStation, exceptions
 from pybikes.utils import PyBikesScraper
 
+try:
+    # Python 2
+    unicode
+except NameError:
+    # Python 3
+    unicode = str
+
 
 class Gbfs(BikeShareSystem):
 

--- a/pybikes/gobike.py
+++ b/pybikes/gobike.py
@@ -3,7 +3,12 @@
 # Distributed under the LGPL license, see LICENSE.txt
 
 import json
-from urlparse import urljoin
+try:
+    # Python 2
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 from lxml import html, etree
 from lxml.cssselect import CSSSelector

--- a/pybikes/nextgal.py
+++ b/pybikes/nextgal.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from urlparse import urljoin
+try:
+    # Python 2
+    from urlparse import urljoin
+except ImportError:
+    # Python 3
+    from urllib.parse import urljoin
 
 from lxml import etree
 

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -3,7 +3,12 @@
 # Distributed under the AGPL license, see LICENSE.txt
 
 import re
-from itertools import imap
+try:
+    # Python 2
+    from itertools import imap as map
+except ImportError:
+    # Python 3
+    pass
 
 import requests
 from shapely.geometry import Polygon, Point, box
@@ -27,7 +32,7 @@ def sp_capwords(word):
         u'ses', u'sa', u'ses'
     ]
     word = word.lower()
-    cap_lambda = lambda (i, w): w.capitalize() if i == 0 or w not in blacklist else w
+    cap_lambda = lambda iw: iw[1].capitalize() if iw[0] == 0 or iw[1] not in blacklist else iw[1]
     return " ".join(map(cap_lambda, enumerate(word.split())))
 
 
@@ -136,6 +141,6 @@ def filter_bounds(things, key, *point_bounds):
 
     for thing in things:
         point = Point(*key(thing))
-        if not any(imap(lambda pol: pol.contains(point), bounds)):
+        if not any(map(lambda pol: pol.contains(point), bounds)):
             continue
         yield thing

--- a/pybikes/veloway.py
+++ b/pybikes/veloway.py
@@ -88,10 +88,10 @@ class VelowayStation(BikeShareStation):
 class VelowayDrupal(Veloway):
 
     # Station 01 - Gare SNCF (Vélos libres : 9 Places libres
-    station_rgx = (ur'Station\s+(?P<id>\d+)\s*-\s*'
-                   ur'(?P<name>.+)\s+'
-                   ur'\(Vélos\s+libres\s*:\s*(?P<bikes>\d+)\s+'
-                   ur'Places\s+libres\s*:\s*(?P<free>\d+)\)')
+    station_rgx = (r'Station\s+(?P<id>\d+)\s*-\s*'
+                   r'(?P<name>.+)\s+'
+                   r'\(Vélos\s+libres\s*:\s*(?P<bikes>\d+)\s+'
+                   r'Places\s+libres\s*:\s*(?P<free>\d+)\)')
 
     def update(self, scraper=None):
         scraper = scraper or utils.PyBikesScraper()

--- a/pybikes/youbike.py
+++ b/pybikes/youbike.py
@@ -3,7 +3,6 @@ import re
 import json
 import zlib
 from pkg_resources import resource_string
-from itertools import imap
 
 from lxml import etree
 

--- a/tests/unittest_pybikes.py
+++ b/tests/unittest_pybikes.py
@@ -10,9 +10,11 @@ import pybikes
 try:
     # Python 2
     basestring
+    unichr
 except NameError:
     # Python 3
     basestring = str
+    unichr = chr
 
 try:
     import keys

--- a/tests/unittest_pybikes.py
+++ b/tests/unittest_pybikes.py
@@ -6,6 +6,14 @@ import unittest
 import sys
 
 import pybikes
+
+try:
+    # Python 2
+    basestring
+except NameError:
+    # Python 3
+    basestring = str
+
 try:
     import keys
 except ImportError:

--- a/utils/filler.py
+++ b/utils/filler.py
@@ -5,17 +5,24 @@
 """ This is a really ugly and nasty script to ease filling up instance files
 without cities, latitudes and longitudes. Does more than it needs to """
 
-import os
-import sys, traceback
+import sys
 import time
 import json
 import argparse
-from urlparse import urlparse
 from collections import namedtuple
 import traceback
 from googlegeocoder import GoogleGeocoder
 from slugify import slugify
 import pybikes
+
+try:
+    # Python 2
+    raw_input
+    unicode
+except NameError:
+    # Python 3
+    raw_input = input
+    unicode = str
 
 geocoder = GoogleGeocoder()
 

--- a/utils/filler.py
+++ b/utils/filler.py
@@ -131,7 +131,7 @@ def geocode(instance, systemCls, language, address = None):
     try:
         info = geocoder.get(query, language = language)
     except Exception as e:
-        print e
+        print(e)
         address = raw_input('Type an address: ')
         return geocode(instance, systemCls, language, address)
     if args.interactive:
@@ -178,7 +178,7 @@ def geocode(instance, systemCls, language, address = None):
                 instance['meta'] = metainfo
                 return True
         except Exception as e:
-            print e
+            print(e)
             return geocode(instance, systemCls, language)
 
     if args.verbose:
@@ -285,7 +285,7 @@ if __name__ == "__main__":
                 traceback.print_exc(file=sys.stderr)
             write_output(data, args.output)
     except KeyboardInterrupt as e:
-        print "KEYBOARD INTERRUPT"
+        print("KEYBOARD INTERRUPT")
         if args.continuous:
             if args.verbose:
                 sys.stderr.write("Writing file bc exception\n")


### PR DESCRIPTION
For https://github.com/eskerda/pybikes/issues/374.

These tests pass for me locally with Python 3.7.4, macOS 10.14.6 Mojave:

```
python tests/unittest_pybikes.py TestBikeShareStationInstance
python tests/unittest_pybikes.py TestBikeShareSystemInstance
python tests/unittest_pybikes.py TestDataFiles
python tests/unittest_pybikes.py TestUtils
```

Also drop support for ancient Python < 2.6, they're EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.5 | 2006-09-19 | 2011-05-26
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01

Source: https://en.wikipedia.org/wiki/CPython#Version_history
