### PR TITLE
fix bicing ebikes

### DIFF
--- a/pybikes/bicing.py
+++ b/pybikes/bicing.py
@@ -37,6 +37,6 @@ class BicingStation(BikeShareStation):
         self.extra = {
             'uid': int(data['id']),
             'online': data['status'] == 1,
-            'has_ebikes': int(data['electrical_bikes'] > 0),
+            'has_ebikes': int(data['electrical_bikes']) > 0,
             'ebikes': int(data['electrical_bikes'])
         }

--- a/pybikes/bicing.py
+++ b/pybikes/bicing.py
@@ -37,5 +37,6 @@ class BicingStation(BikeShareStation):
         self.extra = {
             'uid': int(data['id']),
             'online': data['status'] == 1,
-            'has_ebikes': 'ELECTRIC' in data['type'],
+            'has_ebikes': int(data['electrical_bikes'] > 0,
+            'ebikes': int(data['electrical_bikes'])
         }

--- a/pybikes/bicing.py
+++ b/pybikes/bicing.py
@@ -37,6 +37,6 @@ class BicingStation(BikeShareStation):
         self.extra = {
             'uid': int(data['id']),
             'online': data['status'] == 1,
-            'has_ebikes': int(data['electrical_bikes'] > 0,
+            'has_ebikes': int(data['electrical_bikes'] > 0),
             'ebikes': int(data['electrical_bikes'])
         }


### PR DESCRIPTION
Since Bicing switched to a new station system, pybike's "has_ebikes"  was always set to False for all stations. Also added number of ebikes.