### PR TITLE
fix bicicoruna url

### DIFF
--- a/pybikes/data/nextgal.json
+++ b/pybikes/data/nextgal.json
@@ -9,7 +9,7 @@
                 "longitude": -8.4115,
                 "country": "ES"
             },
-            "url": "http://bicicoruna.es"
+            "url": "https://bicicoruna.es"
         },
         {
             "tag": "bici-ferrol-terra",


### PR DESCRIPTION
I'm pretty sure the request to bici coruña failed because now the url is https