### PR TITLE
Update bike provider for Dresden

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -12,11 +12,11 @@
             }
         },
         {
-            "domain": "sz",
-            "tag": "sz-bike-dresden",
-            "city_uid": 2,
+            "domain": "dx",
+            "tag": "mobibike-dresden",
+            "city_uid": 685,
             "meta": {
-                "name": "sz-bike",
+                "name": "MOBIbike",
                 "city": "Dresden",
                 "country": "DE",
                 "latitude": 51.0535,


### PR DESCRIPTION
The bike provider in Dresden changed from a cooperation of Nextbike with Sächsische Zeitung (szbike) to a cooperation of Nextbike with DVB (MOBIbike).