### PR TITLE
Add ebike support to Motivate systems

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -41,7 +41,8 @@
                     "Motivate International, Inc.",
                     "PBSC Urban Solutions",
                     "BIXI Montréal"
-                ]
+                ],
+                "ebikes": true
             },
             "feed_url": "https://api-core.bixi.com/gbfs/gbfs.json"
         },
@@ -254,7 +255,8 @@
                 "company": [
                     "Motivate International, Inc.",
                     "PBSC Urban Solutions"
-                ]
+                ],
+                "ebikes": true
 
             },
             "feed_url": "https://gbfs.capitalbikeshare.com/gbfs/gbfs.json"
@@ -297,7 +299,8 @@
                     "NYC Bike Share, LLC",
                     "Motivate International, Inc.",
                     "PBSC Urban Solutions"
-                ]
+                ],
+                "ebikes": true
             },
             "feed_url": "https://gbfs.citibikenyc.com/gbfs/gbfs.json"
         },
@@ -327,7 +330,8 @@
                 "company": [
                     "Motivate International, Inc.",
                     "PBSC Urban Solutions"
-                ]
+                ],
+                "ebikes": true
             },
             "feed_url": "https://gbfs.cogobikeshare.com/gbfs/gbfs.json"
         },
@@ -354,7 +358,8 @@
                 "company": [
                     "Motivate International, Inc.",
                     "PBSC Urban Solutions"
-                ]
+                ],
+                "ebikes": true
             },
             "feed_url": "https://gbfs.divvybikes.com/gbfs/gbfs.json"
         },
@@ -456,7 +461,8 @@
                 "company": [
                     "Motivate International, Inc.",
                     "PBSC Urban Solutions"
-                ]
+                ],
+                "ebikes": true
             },
             "feed_url": "https://gbfs.bluebikes.com/gbfs/gbfs.json"
         },

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -127,3 +127,7 @@ class GbfsStation(BikeShareStation):
             'returning': info['is_returning'],
             'last_updated': info['last_reported']
         }
+
+        if 'num_ebikes_available' in info:
+            self.extra['has_ebikes'] = True
+            self.extra['ebikes'] = int(info['num_ebikes_available'])


### PR DESCRIPTION
Motivate adds a field "num_ebikes_available" to their feed. This checks for that and updates the extra property with the number.

Systems that are supported include bixi-montreal, capital-bikeshare, citi-bike-nyc, cogo, divvy and blue-bikes.