### PR TITLE
Add feed for whole Finland

### DIFF
--- a/pybikes/data/otp.json
+++ b/pybikes/data/otp.json
@@ -3,38 +3,14 @@
     "class": "OTP",
     "instances":[
         {
-            "tag":"citybikes-helsinki",
+            "tag":"finland",
             "meta":{
-                "city":"Helsinki",
                 "name":"City bikes",
                 "country":"FI",
-                "company":[
-                    "Helsinki City Transport",
-                    "Helsinki Regional Transport",
-                    "CityBikeFinland",
-                    "Smoove SAS",
-                    "Moventia",
-                    "Alepa"
-                ],
-                "longitude":24.938379,
-                "latitude":60.16985569999999
+                "longitude":27.59,
+                "latitude":64.96
             },
-            "feed_url":"https://api.digitransit.fi/routing/v1/routers/hsl/bike_rental"
-        },
-        {
-            "tag":"foli",
-            "meta":{
-                "city":"Turku",
-                "name":"Föli-fillari",
-                "country":"FI",
-                "company":[
-                    "Turku Region Traffic Föli",
-                    "Nextbike Polska"
-                ],
-                "longitude":22.2666,
-                "latitude":60.4506
-            },
-            "feed_url":"https://api.digitransit.fi/routing/v1/routers/waltti/bike_rental"
+            "feed_url":"https://api.digitransit.fi/routing/v1/routers/finland/bike_rental"
         }
     ]
 }


### PR DESCRIPTION
This replaces the citybikes-helsinki and foli instances with one covering whole Finland.

The old ones are included in this feed, and are thus redundant now. They are also outdated -- I'll post another alternative PR that tries to update them instead of replacing with a whole Finland feed.