### PR TITLE
Fix bicincitta.py url param

### DIFF
--- a/pybikes/bicincitta.py
+++ b/pybikes/bicincitta.py
@@ -15,8 +15,8 @@ from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
 
 
 class BicincittaMixin(object):
-    stations_url = 'http://www.bicincitta.com/frmLeStazioniComune.aspx/RefreshStations'  # NOQA
-    stations_status_url = 'http://www.bicincitta.com/frmLeStazioni.aspx/RefreshPopup'  # NOQA
+    stations_url = 'https://www.bicincitta.com/frmLeStazioniComune.aspx/RefreshStations'  # NOQA
+    stations_status_url = 'https://www.bicincitta.com/frmLeStazioni.aspx/RefreshPopup'  # NOQA
 
     headers = {
         'Content-Type': 'application/json; charset=utf-8',
@@ -42,7 +42,7 @@ class BicincittaMixin(object):
 
 class Bicincitta(BikeShareSystem, BicincittaMixin):
     sync = False
-    endpoint = 'http://www.bicincitta.com/'
+    endpoint = 'https://www.bicincitta.com/'
     source_url = 'frmLeStazioni.aspx?ID={city_id}'
 
     meta = {


### PR DESCRIPTION
The remote server was "upgraded" to https and the original http address route to the homepage.

Example of old url for Udine (Italy) station: 
http://www.bicincitta.com/frmLeStazioniComune.aspx?ID=126 ==> it is routed to homepage (wrongly)
https://www.bicincitta.com/frmLeStazioniComune.aspx?ID=126 ==> OK.

The systems engineers have done a great job 👏...