### PR TITLE
Remove DKVelo service

### DIFF
--- a/pybikes/data/veloway.json
+++ b/pybikes/data/veloway.json
@@ -37,21 +37,6 @@
                     "feed_url": "http://www.vel-in.fr/cartoV2/libProxyCarto.asp"
                 }
             ]
-        },
-        "VelowayDrupal": {
-            "instances": [
-                {
-                    "tag": "dkvelo",
-                    "meta": {
-                        "latitude": 51.0383,
-                        "city": "Dunkerque",
-                        "name": "DK'Vélo",
-                        "longitude": 2.3775,
-                        "country": "FR"
-                    },
-                    "feed_url": "http://www.dk-velo.fr"
-                }
-            ]
         }
     }
 }


### PR DESCRIPTION
Fixes #430. [News confirming](https://www.lavoixdunord.fr/973134/article/2021-04-01/dunkerque-les-dk-velos-definitivement-supprimes) the change.