### PR TITLE
Fix Vél'In feed in Calais(FR)

### DIFF
--- a/pybikes/data/veloway.json
+++ b/pybikes/data/veloway.json
@@ -34,7 +34,7 @@
                         "longitude": 1.85,
                         "country": "FR"
                     },
-                    "feed_url": "http://www.vel-in.fr/cartoV2/libProxyCarto.asp"
+                    "feed_url": "https://velo-vision-prod.azurewebsites.net/calais/oybike/stands.nsf/getsite?site=calais&format=json&key=veolia"
                 }
             ]
         },


### PR DESCRIPTION
Update feed for Vél'In in Calais(FR)
This fixes issue #432 
Ping @eskerda , I hope I have done this right and that it can get merged ;)

P.S. At the end of the new URL feed I scraped from the official Vél'In website (https://www.vel-in.fr/EnTempsReel) there is key=veolia. Can this remain or is there an issue?