### PR TITLE
Update Bay Wheels to a new data feed

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -667,7 +667,7 @@
             "feed_url": "http://ubike.virginia.edu/opendata/gbfs.json"
         },
         {
-            "tag": "ford-gobike",
+            "tag": "bay-wheels",
             "meta": {
                 "latitude": 37.7141454,
                 "longitude": -122.25,
@@ -675,10 +675,10 @@
                 "name": "Bay Wheels",
                 "country": "US",
                 "company": [
-                    "Motivate International, Inc."
+                    "Motivate LLC"
                 ]
             },
-            "feed_url": "https://gbfs.fordgobike.com/gbfs/gbfs.json"
+            "feed_url": "https://gbfs.baywheels.com/gbfs/en/station_status.json"
         },
         {
             "tag": "relay-atlanta",


### PR DESCRIPTION
I just updated the Bay Wheels data feed, thank to @alichass and issue #418 .
I also updated the tag from `ford-gobike` to `bay-wheels`. I don't know if it ok to change this, but I thought the tag was outdated ;)
ping @eskerda 