### PR TITLE
Vélocéa has changed to Vélocéo (Vannes(FR))

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -914,6 +914,20 @@
                 "longitude":4.290833
             },
             "feed_url":"https://saint-etienne-gbfs.klervi.net/gbfs/en/gbfs.json"
+        },
+        {
+			"tag": "veloceo",
+			"meta": {
+				"latitude": 47.6559,
+				"city": "Vannes",
+				"name": "Vélocéo",
+				"longitude": -2.7603,
+				"country": "FR",
+				"company": [
+					"Smoove"
+                ]
+            },
+			"feed_url": "https://vannes-gbfs.klervi.net/gbfs/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/veloway.json
+++ b/pybikes/data/veloway.json
@@ -15,17 +15,6 @@
                     "feed_url": "http://www.velobleu.org/cartoV2/libProxyCarto.asp"
                 },
                 {
-                    "tag": "velocea",
-                    "meta": {
-                        "latitude": 47.6559,
-                        "city": "Vannes",
-                        "name": "Vélocéa",
-                        "longitude": -2.7603,
-                        "country": "FR"
-                    },
-                    "feed_url": "http://www.velocea.fr/cartoV2/libProxyCarto.asp"
-                },
-                {
                     "tag": "vel-in",
                     "meta": {
                         "latitude": 50.95,


### PR DESCRIPTION
Hello @eskerda,
This is a fix to replace old vélocéa by vélocéo feed.