### PR TITLE
Add some old fields to velib

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -963,21 +963,6 @@
                 "longitude": -2.7603
             },
             "feed_url": "https://vannes-gbfs.klervi.net/gbfs/gbfs.json"
-        },
-        {
-             "tag": "velib",
-             "meta": {
-                 "latitude": 48.856614,
-                 "country": "FR",
-                 "name": "Velib' Métropôle",
-                 "longitude": 2.3522219,
-                 "city": "Paris",
-                 "license": {
-                     "name": "OPEN LICENCE 2.0",
-                     "url": "etalab.gouv.fr/wp-content/uploads/2018/11/open-licence.pdf"
-                }
-             },
-             "feed_url": "https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/velib.json
+++ b/pybikes/data/velib.json
@@ -1,0 +1,22 @@
+
+{
+    "instances": [
+        {
+             "tag": "velib",
+             "meta": {
+                 "latitude": 48.856614,
+                 "country": "FR",
+                 "name": "Velib' Métropôle",
+                 "longitude": 2.3522219,
+                 "city": "Paris",
+                 "license": {
+                     "name": "OPEN LICENCE 2.0",
+                     "url": "etalab.gouv.fr/wp-content/uploads/2018/11/open-licence.pdf"
+                }
+             },
+             "feed_url": "https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/gbfs.json"
+        }
+    ],
+    "system": "velib",
+    "class": "Velib"
+}

--- a/pybikes/velib.py
+++ b/pybikes/velib.py
@@ -1,0 +1,31 @@
+from pybikes.gbfs import Gbfs, GbfsStation
+
+class VelibStation(GbfsStation):
+    def __init__(self, info):
+        super(VelibStation, self).__init__(info)
+        # This is the traditional code for a velib station. stationCode is not
+        # on the GBFS specification. Provide stationCode as id, keep station_id
+        # available.
+        self.extra['uid'] = info['stationCode']
+        self.extra['station_id'] = info['station_id']
+
+        # old 'banking' field
+        self.extra['banking'] = 'creditcard' in self.extra.get('payment', [])
+
+        # electric bikes. So far I have not seen this field on other GBFS
+        # systems, so we must investigate. These according to specs go to a
+        # vehicle_types_available field. Here, we have them under a list
+        # of { "name-vehicle": num }.
+
+        for bt in info.get('num_bikes_available_types', []):
+
+            if next(iter(bt)) != 'ebike':
+                continue
+
+            self.extra['ebikes'] = int(bt['ebike'])
+
+            break
+
+
+class Velib(Gbfs):
+    station_cls = VelibStation


### PR DESCRIPTION
It seems to me https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/station_status.json has some fields that are not on the GBFS specification. And that's fine. Either that, or it was part of an old GBFS version?

This makes GBFS accept a `station_cls` field.. I do not want to call this a factory, but it is indeed a factory. Seemed to me the most straightforward way of adding these fields to velib without messing with GBFS and other instances.

(re)adds:
- banking
- uid as station code
- ebikes