### PR TITLE
Add a job summary for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,15 @@ jobs:
       run: make test-instances
     - name: Update instance tests (fail ok)
       run: |
-        make test-update-instances T_FLAGS+="-n 10"
+        # json report does not support 2.7
+        T_FLAGS="-n 10 --junitxml=report/junit.xml"
+        if [[ "${{ matrix.python-version }}" != "2.7" ]]; then
+          T_FLAGS="$T_FLAGS --json-report --json-report-file=report/report.json"
+        fi
+
+        make test-update-instances T_FLAGS+="$T_FLAGS"
       continue-on-error: true
+    - name: summary
+      if: matrix.python-version != '2.7'
+      run: |
+          ./utils/report.py report/report.json --summary >> $GITHUB_STEP_SUMMARY

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ mock; python_version < '3.3'
 
 # Lint
 flake8
+
+# reports
+jinja2
+pytest-json-report; python_version > '2.7'

--- a/utils/report.py
+++ b/utils/report.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+"""
+Generates a md report based on the exported JSON results of a pytest run
+
+$ python utils/report.py .report.json > report.md
+"""
+
+import os
+import re
+import sys
+import json
+import argparse
+from pprint import pformat
+
+from jinja2 import Template
+
+from pybikes.data import _iter_data
+from pybikes.data import _datafile_traversor
+
+
+TEMPLATES_PATH = os.path.dirname(os.path.realpath(__file__))
+FULL_TEMPLATE_PATH = "%s/report.tpl.md" % TEMPLATES_PATH
+SUMMARY_TEMPLATE_PATH = "%s/summary.tpl.md" % TEMPLATES_PATH
+
+parser = argparse.ArgumentParser()
+parser.add_argument('report', type=argparse.FileType('r'))
+parser.add_argument('--template', default=FULL_TEMPLATE_PATH)
+parser.add_argument('--out', type=argparse.FileType('w'), default=sys.stdout)
+parser.add_argument('--summary', action='store_true', default=False)
+args = parser.parse_args()
+
+
+def format_duration(duration):
+    seconds = int(duration)
+    ms = int((duration - seconds) * 1000)
+    if seconds:
+        return "%ds %sms" % (seconds, ms)
+    return "%sms" % ms
+
+
+def format_outcome(outcome):
+    sym = "✅" if outcome == "passed" else "❌"
+    return sym
+
+
+def format_traceback(report):
+    fmt_trace = [
+        'File "%s", line %d, %s' % (t['path'], t['lineno'], t['message'])
+        for t in reversed(report['call']['traceback'])
+    ]
+    fmt_trace.append("\n" + report['call']['crash']['message'])
+
+    return '\n'.join(fmt_trace)
+
+
+def parse_report(report):
+    for test in report['tests']:
+        # only parse instance update tests
+        if not test['nodeid'].startswith('tests/test_instances.py::TestInstance::test_update['):
+            continue
+        cls_attrs = test['keywords'][1]
+        mod, cls, tag = re.search(r'(.*)\.(.*)\:\:(.*)', cls_attrs).groups()
+        yield (mod, cls, tag, test)
+
+
+def generate_report(report, template):
+    report_by_tag = {tag: test for _, _, tag, test in parse_report(report)}
+
+    systems = []
+    for fname, data in _iter_data():
+        instances = data.get('instances')
+
+        # aggregate by class
+        classes = {}
+        for cls, instance in _datafile_traversor(data['class'], instances):
+            if cls not in classes:
+                classes[cls] = []
+            classes[cls].append(instance)
+
+        _classes = []
+
+        for cls, instances in classes.items():
+            _instances = []
+            for instance in instances:
+                tag = instance['tag']
+                _instances.append({
+                      'tag': tag,
+                      'instance': instance,
+                      'report': report_by_tag[tag],
+                })
+
+            passed = filter(lambda i: i['report']['outcome'] == 'passed', _instances)
+            n_passed = len(list(passed))
+            health = n_passed / len(_instances)
+
+            _classes.append({
+                'name': cls,
+                'instances': _instances,
+                'health': n_passed / len(_instances),
+                'failed': len(_instances) - n_passed,
+                'passed': n_passed,
+                'total': len(_instances),
+            })
+
+        health = sum(map(lambda c: c['health'], _classes)) / len(_classes)
+        passed = sum(map(lambda c: c['passed'], _classes))
+        failed = sum(map(lambda c: c['failed'], _classes))
+        systems.append({
+            'name': data['system'],
+            'classes': _classes,
+            'passed': passed,
+            'failed': failed,
+            'total': passed + failed,
+            'health': health,
+        })
+
+    sorted_systems = sorted(systems, key=lambda s: s['health'])
+
+    passed = sum(map(lambda s: s['passed'], systems))
+    failed = sum(map(lambda s: s['failed'], systems))
+    total = passed + failed
+
+    tpl = Template(template, trim_blocks=True, lstrip_blocks=True)
+    return tpl.render(
+        health={'passed': passed, 'failed': failed, 'total': total},
+        systems=sorted_systems,
+        version=report['environment']['Python'],
+        pformat=pformat,
+        len=len,
+        int=int,
+        format_duration=format_duration,
+        format_outcome=format_outcome,
+        format_traceback=format_traceback,
+    )
+
+
+if __name__ == "__main__":
+    report = json.loads(args.report.read())
+    if args.summary:
+        template = open(SUMMARY_TEMPLATE_PATH).read()
+    else:
+        template = open(args.template).read()
+    report_md = generate_report(report, template)
+
+    args.out.write(report_md)

--- a/utils/report.tpl.md
+++ b/utils/report.tpl.md
@@ -1,0 +1,60 @@
+# systems status report (Python {{ version }})
+
+| overall success rate | {{ int((health.passed / health.total) * 100) }}% |
+|-|-|
+| passed | {{ health.passed }} |
+| failed | {{ health.failed }} |
+| total  | {{ health.total }} |
+
+| | class    | instances | success rate |
+|-|----------|-----------|--------------|
+{% for system in systems %}
+    {% for cls in system.classes %}
+|{{format_outcome("passed" if cls.failed == 0)}}| [{{system.name}}.{{ cls.name }}](#cls-{{ cls.name }}-{{ version }}) | {{ cls.total }} | {{ int((cls.passed / cls.total) * 100) }}% |
+    {% endfor %}
+{% endfor %}
+
+---
+
+{% for system in systems %}
+    {% for cls in system.classes %}
+## <a name="cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
+
+| | instance | outcome | duration |
+|-|----------|---------|----------|
+        {% for instance in cls.instances %}
+|{{format_outcome(instance.report.outcome)}}|[{{system.name}}.{{cls.name}}::{{instance.tag}}](#tag-{{instance.tag}}-{{version}})|{{instance.report.outcome}}|{{format_duration(instance.report.call.duration)}}|
+        {% endfor %}
+
+    {% endfor %}
+{% endfor %}
+
+---
+
+{% for system in systems %}
+    {% for cls in system.classes %}
+        {% for instance in cls.instances %}
+---
+### <a name="tag-{{instance.tag}}-{{version}}">{{system.name}}.{{cls.name}}::{{instance.tag}}</a>
+
+```
+{{ pformat(instance.instance) }}
+```
+
+            {% if instance.report.outcome == "failed" %}
+#### Error Traceback
+
+```
+{{ format_traceback(instance.report) }}
+```
+<details>
+    <summary>Full traceback</summary>
+    <pre>
+{{ instance.report.call.longrepr }}
+    </pre>
+</details>
+            {% endif %}
+
+        {% endfor %}
+    {% endfor %}
+{% endfor %}

--- a/utils/summary.tpl.md
+++ b/utils/summary.tpl.md
@@ -1,0 +1,30 @@
+# systems status report (Python {{ version }})
+
+| overall success rate | {{ int((health.passed / health.total) * 100) }}% |
+|-|-|
+| passed | {{ health.passed }} |
+| failed | {{ health.failed }} |
+| total  | {{ health.total }} |
+
+| | class    | instances | success rate |
+|-|----------|-----------|--------------|
+{% for system in systems %}
+    {% for cls in system.classes %}
+|{{format_outcome("passed" if cls.failed == 0)}}| [{{system.name}}.{{ cls.name }}](#cls-{{ cls.name }}-{{ version }}) | {{ cls.total }} | {{ int((cls.passed / cls.total) * 100) }}% |
+    {% endfor %}
+{% endfor %}
+
+---
+
+{% for system in systems %}
+    {% for cls in system.classes %}
+## <a name="cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
+
+| | instance | outcome | duration |
+|-|----------|---------|----------|
+        {% for instance in cls.instances %}
+|{{format_outcome(instance.report.outcome)}}|[{{system.name}}.{{cls.name}}::{{instance.tag}}](#tag-{{instance.tag}}-{{version}})|{{instance.report.outcome}}|{{format_duration(instance.report.call.duration)}}|
+        {% endfor %}
+
+    {% endfor %}
+{% endfor %}


### PR DESCRIPTION
It's not perfect. Github workflows does not support rendering an artifact, so this uses a feature called workflow summary, that is limited to 1MB.

Ideally, we upload markdown artifacts and these get rendered and can be linked. Note that this could still be possible, uploading artifacts and then getting artifacts on another step that puts it on github pages somewhere.