### PR TITLE
update nextbike cities (also fixes #392)

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -3021,6 +3021,159 @@
                 "latitude": 45.5054,
                 "longitude": 13.5979
             }
+        },
+        {
+            "domain": "hg",
+            "tag": "heraeus-hanau",
+            "city_uid": 301,
+            "meta": {
+                "name": "Heraeus Hanau",
+                "city": "Hanau",
+                "country": "DE",
+                "latitude": 50.1387,
+                "longitude": 8.94429,
+                "company":[
+                    "Heraeus Holding GmbH"
+                ]
+            }
+        },
+        {
+            "domain": "ol",
+            "tag": "stari-grad-hvar",
+            "city_uid": 745,
+            "meta": {
+                "name": "Hvar",
+                "city": "Stari Grad",
+                "country": "HR",
+                "latitude": 43.1841,
+                "longitude": 16.5886
+            }
+        },
+        {
+            "domain": "re",
+            "tag": "revgmobic",
+            "city_uid": 817,
+            "meta": {
+                "name": "mobic",
+                "city": "REVG",
+                "country": "DE",
+                "latitude": 50.8493,
+                "longitude": 6.6687,
+                "company":[
+                    "Rhein-Erft-Verkehrsgesellschaft mbH"
+                ]
+            }
+        },
+        {
+            "domain": "gh",
+            "tag": "westbike-erkelenz",
+            "city_uid": 807,
+            "meta": {
+                "name": "westBike",
+                "city": "Erkelenz",
+                "country": "DE",
+                "latitude": 51.0753,
+                "longitude": 6.31233
+            }
+        },
+        {
+            "domain": "gh",
+            "tag": "westbike-geilenkirchen",
+            "city_uid": 808,
+            "meta": {
+                "name": "westBike",
+                "city": "Geilenkirchen",
+                "country": "DE",
+                "latitude": 50.9671,
+                "longitude": 6.11886
+            }
+        },
+        {
+            "domain": "gh",
+            "tag": "westbike-heinsberg",
+            "city_uid": 809,
+            "meta": {
+                "name": "westBike",
+                "city": "Heinsberg",
+                "country": "DE",
+                "latitude": 51.0597,
+                "longitude": 6.11849
+            }
+        },
+        {
+            "domain": "gh",
+            "tag": "westbike-hueckelhoven",
+            "city_uid": 810,
+            "meta": {
+                "name": "westBike",
+                "city": "H\u00fcckelhoven",
+                "country": "DE",
+                "latitude": 51.0529,
+                "longitude": 6.21933
+            }
+        },
+        {
+            "domain": "gh",
+            "tag": "westbike-wegberg",
+            "city_uid": 811,
+            "meta": {
+                "name": "westBike",
+                "city": "Wegberg",
+                "country": "DE",
+                "latitude": 51.1427,
+                "longitude": 6.2813
+            }
+        },
+        {
+            "domain": "ed",
+            "tag": "edeka-gruenheide-mark",
+            "city_uid": 819,
+            "meta": {
+                "name": "EDEKA Gr\u00fcnheide",
+                "city": "Gr\u00fcnheide (Mark)",
+                "country": "DE",
+                "latitude": 52.4247,
+                "longitude": 13.8203
+            }
+        },
+        {
+            "domain": "er",
+            "tag": "nextbike-erlangen",
+            "city_uid": 829,
+            "meta": {
+                "name": "nextbike Erlangen",
+                "city": "Erlangen",
+                "country": "DE",
+                "latitude": 49.589,
+                "longitude": 11.0065
+            }
+        },
+        {
+            "domain": "cd",
+            "tag": "nomago-gorizia",
+            "city_uid": 771,
+            "meta": {
+                "name": "GO2GO - Gorizia",
+                "city": "Gorizia",
+                "country": "IT",
+                "latitude": 45.9469,
+                "longitude": 13.6208
+            }
+        },
+        {
+            "domain": "mz",
+            "tag": "mvg-meinrad-nextbike-mainz",
+            "city_uid": 771,
+            "meta": {
+                "name": "meinRad MVG Mainz",
+                "city": "Mainz",
+                "country": "DE",
+                "latitude": 45.9469,
+                "longitude": 13.6208,
+                "company": [
+                    "Mainzer Verkehrsgesellschaft mbH"
+                ]
+            }
         }
     ],
     "system": "nextbike",


### PR DESCRIPTION
Hi @eskerda,

I tune back in for another **nextbike data** update.

As the title suggests this issue fixes the outdated information for Mainz (Germany) as noted in #392. It also introduces an update for *VAG_Rad* as they split up their service 'places' (see *nextbike Erlangen*).

There are also a few little spots propably pilot/demos (see e.g. *westBike*) as [discussed](https://github.com/eskerda/pybikes/pull/495#issuecomment-1203285798) in #495 back in August 2022. So they are way less important from my personal point view.

[*REVG*](https://revg.de/) / *mobic* is a major provider offering 80 *places* in and around Frechen (Germany).[^1] So including them would be great.

Regards,

Jean-Luc

[^1]: near Köln (Cologne) in the Ruhr area