### PR TITLE
Fix Velopop (Avignon)

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -908,6 +908,20 @@
             "feed_url":"https://saint-etienne-gbfs.klervi.net/gbfs/en/gbfs.json"
         },
         {
+            "tag":"velopop",
+            "meta":{
+                "city":"Avignon",
+                "name":"V\u00e9lopop",
+                "country":"FR",
+                "company": [
+                    "Smoove"
+                ],
+                "latitude":43.943689,
+                "longitude":4.805833
+            },
+            "feed_url":"https://avignon-gbfs.klervi.net/gbfs/en/station_information.json"
+        },
+        {
             "tag":"c-velo",
             "meta":{
                 "city":"Clermont-Ferrand",

--- a/pybikes/data/smoove.json
+++ b/pybikes/data/smoove.json
@@ -25,17 +25,6 @@
         "Smoove":{
             "instances":[
                 {
-                    "tag":"velopop",
-                    "meta":{
-                        "latitude":43.943689,
-                        "city":"Avignon",
-                        "name":"V\u00e9lopop",
-                        "longitude":4.805833,
-                        "country":"FR"
-                    },
-                    "feed_url":"http://cli-velo-avignon.gir.fr/stations_inc.html"
-                },
-                {
                     "tag":"batumvelo",
                     "meta":{
                         "latitude":41.660906,


### PR DESCRIPTION
documentation: https://transport.data.gouv.fr/datasets/velos-libre-service-grand-avignon-velopop-disponibilite-en-temps-reel