### PR TITLE
Clermont-Ferrand: Update to v2 GBFS

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -920,7 +920,7 @@
                 "latitude":45.7831, 
                 "longitude":3.0824
             },
-            "feed_url":"https://clermontferrand.publicbikesystem.net/customer/ube/gbfs/v1/"
+            "feed_url":"https://opendata.clermontmetropole.eu/api/v2/catalog/datasets/etat-des-stations-vls-c-velo-gbfs"
         },
         {
             "tag": "monabike",


### PR DESCRIPTION
documentation: https://transport.data.gouv.fr/datasets/etat-des-stations-de-velos-en-libre-service-c-velo-gbfs-du-syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-1