### PR TITLE
[minor change] fix a typo in name "Vélib' Métropole"

### DIFF
--- a/pybikes/data/velib.json
+++ b/pybikes/data/velib.json
@@ -5,7 +5,7 @@
             "meta": {
                 "latitude": 48.856614,
                 "country": "FR",
-                "name": "Velib' Métropôle",
+                "name": "Vélib' Métropole",
                 "longitude": 2.3522219,
                 "city": "Paris",
                 "license": {


### PR DESCRIPTION
source: https://fr.wikipedia.org/wiki/V%C3%A9lib'_M%C3%A9tropole