### PR TITLE
Fix markdown links in CI jobs

### DIFF
--- a/utils/summary.tpl.md
+++ b/utils/summary.tpl.md
@@ -18,7 +18,7 @@
 
 {% for system in systems %}
     {% for cls in system.classes %}
-## <a name="cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
+## <a name="user-content-cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
 
 | | instance | outcome | duration |
 |-|----------|---------|----------|


### PR DESCRIPTION
Add prefix "user-content-"

## documentation
i.e: "cls-keolisstar-3.9.16" => "user-content-cls-keolisstar-3.9.16"