### PR TITLE
add PubliBike (CH)

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -1031,19 +1031,6 @@
         },
         {
             "city_ids": [
-                123,
-                124
-            ],
-            "meta": {
-                "latitude": 46.5196535,
-                "city": "Lausanne - Morges - Campus",
-                "longitude": 6.6322734,
-                "country": "CH"
-            },
-            "tag": "bicincitta-lausanne-campus-morges"
-        },
-        {
-            "city_ids": [
                 106
             ],
             "meta": {
@@ -1065,18 +1052,6 @@
                 "country": "IT"
             },
             "tag": "bicincitta-livorno"
-        },
-        {
-            "city_ids": [
-                89
-            ],
-            "meta": {
-                "latitude": 46.2331221,
-                "city": "Sion",
-                "longitude": 7.360625999999999,
-                "country": "CH"
-            },
-            "tag": "bicincitta-valais-central"
         },
         {
             "city_ids": [
@@ -1217,18 +1192,6 @@
         },
         {
             "city_ids": [
-                33
-            ],
-            "meta": {
-                "latitude": 46.8064773,
-                "city": "Fribourg",
-                "longitude": 7.161971899999999,
-                "country": "CH"
-            },
-            "tag": "bicincitta-agglo-fribourg"
-        },
-        {
-            "city_ids": [
                 180
             ],
             "meta": {
@@ -1252,30 +1215,6 @@
                 "country": "IT"
             },
             "tag": "bicincitta-brancaleone"
-        },
-        {
-            "city_ids": [
-                34
-            ],
-            "meta": {
-                "latitude": 46.6154512,
-                "city": "Bulle",
-                "longitude": 7.057726799999999,
-                "country": "CH"
-            },
-            "tag": "bicincitta-bulle"
-        },
-        {
-            "city_ids": [
-                129
-            ],
-            "meta": {
-                "latitude": 46.4628333,
-                "city": "Distretto della Riviera-Pays-d'Enhaut",
-                "longitude": 6.8419192,
-                "country": "CH"
-            },
-            "tag": "bicincitta-riviera"
         },
         {
             "city_ids": [
@@ -1414,18 +1353,6 @@
         },
         {
             "city_ids": [
-                116
-            ],
-            "meta": {
-                "latitude": 46.7784736,
-                "city": "Yverdon-les-Bains",
-                "longitude": 6.641183,
-                "country": "CH"
-            },
-            "tag": "bicincitta-yverdon-les-bains"
-        },
-        {
-            "city_ids": [
                 224
             ],
             "meta": {
@@ -1447,30 +1374,6 @@
                 "country": "IT"
             },
             "tag": "bicincitta-morigerati"
-        },
-        {
-            "city_ids": [
-                32
-            ],
-            "meta": {
-                "latitude": 46.3832683,
-                "city": "Nyon",
-                "longitude": 6.2347852,
-                "country": "CH"
-            },
-            "tag": "bicincitta-la-cote"
-        },
-        {
-            "city_ids": [
-                60
-            ],
-            "meta": {
-                "latitude": 46.2521873,
-                "city": "Monthey - Aigle",
-                "longitude": 6.9469598,
-                "country": "CH"
-            },
-            "tag": "bicincitta-chablais"
         },
         {
             "city_ids": [
@@ -1509,18 +1412,6 @@
             },
             "tag": "bicincitta-cesena",
             "endpoint": "http://www.mimuovoinbici.it/"
-        },
-        {
-            "city_ids": [
-                130
-            ],
-            "meta": {
-                "latitude": 45.9907174,
-                "city": "Paradiso",
-                "longitude": 8.945261799999999,
-                "country": "CH"
-            },
-            "tag": "bicincitta-lugano-paradiso"
         },
         {
             "city_ids": [
@@ -1595,18 +1486,6 @@
                 "country": "IT"
             },
             "tag": "bicincitta-lavis"
-        },
-        {
-            "city_ids": [
-                35
-            ],
-            "meta": {
-                "latitude": 46.92922110000001,
-                "city": "Murten",
-                "longitude": 7.120184,
-                "country": "CH"
-            },
-            "tag": "bicincitta-les-lacs-romont"
         },
         {
             "city_ids": [

--- a/pybikes/data/publibike.json
+++ b/pybikes/data/publibike.json
@@ -1,0 +1,16 @@
+{
+    "instances": [
+        {
+            "tag": "publibike",
+            "meta": {
+                "latitude": 0, 
+                "city": "", 
+                "name": "", 
+                "longitude": 0, 
+                "country": "CH"
+            }
+        }
+    ], 
+    "system": "publibike", 
+    "class": "Publibike"
+}

--- a/pybikes/data/publibike.json
+++ b/pybikes/data/publibike.json
@@ -1,12 +1,90 @@
 {
     "instances": [
         {
-            "tag": "publibike",
+            "city_uid": 6,
+            "tag": "publibike-zuerich",
             "meta": {
-                "latitude": 0, 
-                "city": "", 
-                "name": "", 
-                "longitude": 0, 
+                "latitude": 47.38728,
+                "city": "Z\u00fcrich",
+                "name": "PubliBike Z\u00fcrich",
+                "longitude": 8.53767,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 10,
+            "tag": "publibike-sierre",
+            "meta": {
+                "latitude": 46.28986,
+                "city": "Sierre",
+                "name": "PubliBike Sierre",
+                "longitude": 7.53194,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 9,
+            "tag": "publibike-region-de-nyon",
+            "meta": {
+                "latitude": 46.381706,
+                "city": "Nyon",
+                "name": "PubliBike R\u00e9gion de Nyon",
+                "longitude": 6.240311,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 5,
+            "tag": "publibike-bern",
+            "meta": {
+                "latitude": 46.94841,
+                "city": "Bern",
+                "name": "PubliBike Bern",
+                "longitude": 7.43767,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 3,
+            "tag": "publibike-sottoceneri-ti",
+            "meta": {
+                "latitude": 46.00491,
+                "city": "Lugano",
+                "name": "PubliBike Sottoceneri (TI)",
+                "longitude": 8.95244,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 8,
+            "tag": "publibike-fribourg",
+            "meta": {
+                "latitude": 46.805708,
+                "city": "Fribourg",
+                "name": "PubliBike Fribourg",
+                "longitude": 7.160339,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 2,
+            "tag": "publibike-lausanne-morges",
+            "meta": {
+                "latitude": 46.516649,
+                "city": "Lausanne",
+                "name": "PubliBike Lausanne-Morges",
+                "longitude": 6.62948,
+                "country": "CH"
+            }
+        },
+        {
+            "city_uid": 4,
+            "tag": "publibike-sion",
+            "meta": {
+                "latitude": 46.228227,
+                "city": "Sion",
+                "name": "PubliBike Sion",
+                "longitude": 7.358901,
                 "country": "CH"
             }
         }

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -20,7 +20,7 @@ cache = TSTCache(delta=60)
 
 class Publibike(BikeShareSystem):
     sync = True
-    unifeed = True # all 'networks' (instances) share the same feed
+    unifeed = True  # all 'networks' (instances) share the same feed
 
     meta = {
         'system': 'PubliBike',
@@ -28,12 +28,10 @@ class Publibike(BikeShareSystem):
         'source': 'https://api.publibike.ch/v1/static/api.html'
     }
 
-    def __init__(self, tag, meta, city_uid, hostname='api.publibike.ch',
-                 bbox=None):
+    def __init__(self, tag, meta, city_uid, hostname='api.publibike.ch'):
         super(Publibike, self).__init__(tag, meta)
         self.url = BASE_URL.format(hostname=hostname)
         self.uid = city_uid
-        self.bbox = bbox
 
     def update(self, scraper=None):
         if scraper is None:
@@ -45,18 +43,12 @@ class Publibike(BikeShareSystem):
         )
 
         assert "stations" in stations, "Failed to find any PubliBike stations"
-            
+
         stations = stations['stations']
 
         # currently (Dezember 2022) there is no endpoint available to query only stations for 'city_uid'
         # so we need to filter the data
         stations = filter(lambda s: s['network']['id'] == self.uid, stations)
-
-        if self.bbox:
-            def getter(station):
-                lat, lng = station['latitude'], station['longitude']
-                return (float(lat), float(lng))
-            stations = filter_bounds(stations, getter, self.bbox)
 
         self.stations = list(map(PublibikeStation, stations))
 
@@ -64,14 +56,14 @@ class Publibike(BikeShareSystem):
 class PublibikeStation(BikeShareStation):
     def __init__(self, station):
         super(PublibikeStation, self).__init__()
-        
+
         self.name = station['name']
         self.latitude = float(station['latitude'])
         self.longitude = float(station['longitude'])
         self.extra = {}
 
         self.extra['uid'] = station['id']
-        
+
         if 'address' in station:
             self.extra['address'] = station['address']
 
@@ -84,7 +76,7 @@ class PublibikeStation(BikeShareStation):
         self.bikes = 0
         if "vehicles" in station:
             self.bikes = len(station['vehicles'])
-  
+
         self.free = None
         if "capacity" in station:
             try:

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2010-2022, eskerda <eskerda@gmail.com>
+# Distributed under the AGPL license, see LICENSE.txt
+
+import re
+import json
+
+from .base import BikeShareSystem, BikeShareStation
+from pybikes.utils import PyBikesScraper, filter_bounds
+from pybikes.contrib import TSTCache
+
+__all__ = ['Publibike', 'PublibikeStation']
+
+BASE_URL = 'https://{hostname}/v1/public/partner/stations'
+
+# Since most networks share the same hostname, there's no need to keep hitting
+# the endpoint on the same urls. This caches the feed for 60s
+cache = TSTCache(delta=60)
+
+
+class Publibike(BikeShareSystem):
+    sync = True
+    unifeed = True
+
+    meta = {
+        'system': 'PubliBike',
+        'company': ['PubliBike AG']
+    }
+
+    def __init__(self, tag, meta, city_uid, hostname='api.publibike.ch',
+                 bbox=None):
+        super(Publibike, self).__init__(tag, meta)
+        self.url = BASE_URL.format(hostname=hostname, domain=domain)
+        self.uid = city_uid
+        self.bbox = bbox
+
+    def update(self, scraper=None):
+        if scraper is None:
+            scraper = PyBikesScraper(cache)
+        stations = json.loads(
+            scraper.request(self.url).encode('utf-8')
+        )
+
+        assert "stations" in stations, "Failed to find any PubliBike stations"
+            
+        stations = stations['stations']
+
+        if self.bbox:
+            def getter(station):
+                lat, lng = station['latitude'], station['longitude']
+                return (float(lat), float(lng))
+            stations = filter_bounds(stations, getter, self.bbox)
+
+        self.stations = list(map(PublibikeStation, stations))
+
+
+class PublibikeStation(BikeShareStation):
+    def __init__(self, station):
+        super(PublibikeStation, self).__init__()
+        
+        self.name = station['name']
+        self.latitude = float(station['latitude'])
+        self.longitude = float(station['longitude'])
+        self.extra = {}
+
+        self.extra['uid'] = station['id']
+        
+        if 'address' in station:
+            self.extra['address'] = station['address']
+
+        if 'zip' in station:
+            self.extra['zip'] = station['zip']
+
+        if 'city' in station:
+            self.extra['city'] = station['city']
+
+        self.bikes = 0
+        if "vehicles" in station:
+            self.bikes = len(station['vehicles'])
+  
+        self.free = None
+        if "capacity" in station:
+            try:
+                self.extra['slots'] = int(station['capacity'])
+            except TypeError:
+                self.extra['slots'] = 0
+
+            if self.extra['slots'] > 0:
+                self.free = self.extra['slots'] - self.bikes
+
+        if 'bike_numbers' in station:
+            self.extra['bike_uids'] = station['bike_numbers'].split(',')

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -20,7 +20,7 @@ cache = TSTCache(delta=60)
 
 class Publibike(BikeShareSystem):
     sync = True
-    unifeed = True
+    unifeed = True # all 'networks' (instances) share the same feed
 
     meta = {
         'system': 'PubliBike',
@@ -30,7 +30,7 @@ class Publibike(BikeShareSystem):
     def __init__(self, tag, meta, city_uid, hostname='api.publibike.ch',
                  bbox=None):
         super(Publibike, self).__init__(tag, meta)
-        self.url = BASE_URL.format(hostname=hostname, domain=domain)
+        self.url = BASE_URL.format(hostname=hostname)
         self.uid = city_uid
         self.bbox = bbox
 
@@ -44,6 +44,10 @@ class Publibike(BikeShareSystem):
         assert "stations" in stations, "Failed to find any PubliBike stations"
             
         stations = stations['stations']
+
+        # currently (Dezember 2022) there is no endpoint available to query only stations for 'city_uid'
+        # so we need to filter the data
+        stations = filter(lambda s: s['network']['id'] == self.uid, stations)
 
         if self.bbox:
             def getter(station):
@@ -87,6 +91,3 @@ class PublibikeStation(BikeShareStation):
 
             if self.extra['slots'] > 0:
                 self.free = self.extra['slots'] - self.bikes
-
-        if 'bike_numbers' in station:
-            self.extra['bike_uids'] = station['bike_numbers'].split(',')

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2010-2022, eskerda <eskerda@gmail.com>
-# Copyright (C) 2022, eUgEntOptIc44 (https://github.com/eUgEntOptIc44)
+# Copyright (C) 2022-2023, eUgEntOptIc44 (https://github.com/eUgEntOptIc44)
 # Distributed under the AGPL license, see LICENSE.txt
 
-import re
 import json
 
 from .base import BikeShareSystem, BikeShareStation
-from pybikes.utils import PyBikesScraper, filter_bounds
+from pybikes.utils import PyBikesScraper
 from pybikes.contrib import TSTCache
 
 __all__ = ['Publibike', 'PublibikeStation']
@@ -46,7 +45,8 @@ class Publibike(BikeShareSystem):
 
         stations = stations['stations']
 
-        # currently (Dezember 2022) there is no endpoint available to query only stations for 'city_uid'
+        # currently (Dezember 2022) there is no endpoint available
+        # to query only stations for 'city_uid'
         # so we need to filter the data
         stations = filter(lambda s: s['network']['id'] == self.uid, stations)
 
@@ -78,11 +78,10 @@ class PublibikeStation(BikeShareStation):
             self.bikes = len(station['vehicles'])
 
         self.free = None
-        if "capacity" in station:
-            try:
-                self.extra['slots'] = int(station['capacity'])
-            except TypeError:
-                self.extra['slots'] = 0
+        try:
+            self.extra['slots'] = station['capacity']
+        except TypeError:
+            self.extra['slots'] = 0
 
-            if self.extra['slots'] > 0:
-                self.free = self.extra['slots'] - self.bikes
+        if self.extra['slots'] > 0:
+            self.free = self.extra['slots'] - self.bikes

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -5,8 +5,7 @@
 
 import json
 
-from .base import BikeShareSystem, BikeShareStation
-from pybikes.utils import PyBikesScraper
+from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
 from pybikes.contrib import TSTCache
 
 FEED_URL = 'https://api.publibike.ch/v1/public/partner/stations'
@@ -57,25 +56,12 @@ class PublibikeStation(BikeShareStation):
         self.name = station['name']
         self.latitude = float(station['latitude'])
         self.longitude = float(station['longitude'])
-        self.extra = {}
-
-        self.extra['uid'] = station['id']
-
-        if 'address' in station:
-            self.extra['address'] = station['address']
-
-        if 'zip' in station:
-            self.extra['zip'] = station['zip']
-
-        if 'city' in station:
-            self.extra['city'] = station['city']
-
-        self.bikes = 0
-        if "vehicles" in station:
-            self.bikes = len(station['vehicles'])
-
-        self.free = None
-        self.extra['slots'] = station.get('capacity', 0)
-
-        if self.extra['slots'] > 0:
-            self.free = self.extra['slots'] - self.bikes
+        self.extra = {
+            'uid': station['id'],
+            'address': station['address'],
+            'zip': station['zip'],
+            'city': station['city'],
+            'slots': station['capacity'],
+        }
+        self.bikes = len(station['vehicles'])
+        self.free = self.extra['slots'] - self.bikes

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2010-2022, eskerda <eskerda@gmail.com>
+# Copyright (C) 2022, eUgEntOptIc44 (https://github.com/eUgEntOptIc44)
 # Distributed under the AGPL license, see LICENSE.txt
 
 import re

--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -14,8 +14,7 @@ __all__ = ['Publibike', 'PublibikeStation']
 
 BASE_URL = 'https://{hostname}/v1/public/partner/stations'
 
-# Since most networks share the same hostname, there's no need to keep hitting
-# the endpoint on the same urls. This caches the feed for 60s
+# caches the feed for 60s
 cache = TSTCache(delta=60)
 
 
@@ -25,7 +24,8 @@ class Publibike(BikeShareSystem):
 
     meta = {
         'system': 'PubliBike',
-        'company': ['PubliBike AG']
+        'company': ['PubliBike AG'],
+        'source': 'https://api.publibike.ch/v1/static/api.html'
     }
 
     def __init__(self, tag, meta, city_uid, hostname='api.publibike.ch',
@@ -37,7 +37,9 @@ class Publibike(BikeShareSystem):
 
     def update(self, scraper=None):
         if scraper is None:
+            # use cached feed if possible
             scraper = PyBikesScraper(cache)
+
         stations = json.loads(
             scraper.request(self.url).encode('utf-8')
         )


### PR DESCRIPTION
fix #337

Hi @eskerda 

As [mentioned](https://github.com/eskerda/pybikes/pull/514#issuecomment-1358657123) in #514 I looked into the possible integration of [*PubliBike*](https://www.publibike.ch/en/home) a bike sharing provider in Switzerland.

Unfortunately *PubliBike* does **not** offer to request only stations of a single *network*[^1]. Please also see their [OpenAPI](https://api.publibike.ch/v1/static/api.html) docs for more details.

Therefore I rely on the **caching** of `pybikes` and filter the api answer by the network's `id`. This allows to easily migrate to a possible future endpoint for the networks.

Looking forward to your feedback. I'd also like to wish everyone a Merry Christmas and only the very best for 2023.

Regards,

Jean-Luc

[^1]: *Nextbike* would call them *domains*.