### PR TITLE
WIP: check if coordinates of GBFS stations are None

### DIFF
--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2010-2012, eskerda <eskerda@gmail.com>
+# Copyright (C) 2010-2023, eskerda <eskerda@gmail.com>
+# Copyright (C) 2023, eUgEntOptIc44 (https://github.com/eUgEntOptIc44)
 # Distributed under the AGPL license, see LICENSE.txt
 
 import json
@@ -112,6 +113,10 @@ class Gbfs(BikeShareSystem):
         ]
         self.stations = []
         for info, status in stations:
+            if info['lat'] == None or info['lon'] == None:
+                #TODO: raise exception ?!
+                continue
+
             info.update(status)
             try:
                 station = self.station_cls(info)


### PR DESCRIPTION
As mentioned in #517 I had noticed that the [gbfs.py](https://github.com/eskerda/pybikes/blob/24e40351678fa22f74af0aa7da3f7a326eee7e2e/pybikes/gbfs.py#L114) parser fails on feeds containing stations with missing (`null` / `None`) coordinates.

This PR is meant to serve as a starter for a fix of this inconvience. As of writing the parser would silently skip stations with missing coordinates. As noted inline I think that some feedback to the user would be required. Should the parser `print()` an error message? Throwing an **exception** would to my personal understanding break the parsing loop.

As the title suggests this PR is WIP as of publishing. Please feel free to comment on this and provide feedback.