### PR TITLE
update the gbfs feed for Portland, OR (fix #521)

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -128,11 +128,10 @@
                 "country": "US",
                 "company": [
                     "Portland Bureau of Transportation (PBOT)",
-                    "Motivate International, Inc",
-                    "Social Bicycles Inc."
+                    "Lyft Inc."
                 ]
             },
-            "feed_url": "http://biketownpdx.socialbicycles.com/opendata/gbfs.json"
+            "feed_url": "https://gbfs.biketownpdx.com/gbfs/gbfs.json"
         },
         {
             "tag": "britebikes",


### PR DESCRIPTION
fix #521

Hi @eskerda 

As mentioned by @Manu1400 in #521 the GBFS feed for Portland, OR (USA) has changed. As of writing *Lyft* is the new provider.

Regards,

Jean-Luc