### PR TITLE
minor improvement to test_data

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -84,9 +84,15 @@ def _iter_data():
 @patch('pybikes.data._t_cache', {})
 @patch('pybikes.data._traversor', _traverse_lib())
 class TestData:
+
     def test_find_not_found(self):
         with pytest.raises(BikeShareSystemNotFound):
             find("abracadabra")
+    
+
+    def test_find_not_found_empty_tag(self):
+        with pytest.raises(BikeShareSystemNotFound):
+            find("")
 
 
     def test_find_single_class(self):
@@ -106,6 +112,11 @@ class TestData:
     def test_get_not_found(self):
         with pytest.raises(BikeShareSystemNotFound):
             get("abracadabra")
+
+
+    def test_get_not_found_empty_tag(self):
+        with pytest.raises(BikeShareSystemNotFound):
+            get("")
 
 
     def test_get_instances(self):


### PR DESCRIPTION
This PR adds two tests to `test_data` to cover some untested exception cases, ie, when the tag is empty.

Thus, it creates two tests:
- test_find_not_found_empty_tag
- test_get_not_found_empty_tag