### PR TITLE
[ci] fix summary anchors and size

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,8 @@ jobs:
         T_FLAGS="$T_FLAGS --json-report --json-report-file=report/report.json"
         # allowed to fail for test runs
         make test-update T_FLAGS+="$T_FLAGS" || true
+    # Only run summary once
     - name: summary
-      if: (success() || failure())
+      if: (success() || failure()) && matrix.python-version == '3.8'
       run: |
           ./utils/report.py report/report.json >> $GITHUB_STEP_SUMMARY

--- a/utils/report.tpl.md
+++ b/utils/report.tpl.md
@@ -10,7 +10,7 @@
 |-|----------|-----------|--------------|
 {% for system in systems %}
     {% for cls in system.classes %}
-|{{format_outcome("passed" if cls.failed == 0)}}| [{{system.name}}.{{ cls.name }}](#cls-{{ cls.name }}-{{ version }}) | {{ cls.total }} | {{ int((cls.passed / cls.total) * 100) }}% |
+|{{format_outcome("passed" if cls.failed == 0)}}| [{{system.name}}.{{ cls.name }}](#user-content-cls-{{cls.name|lower}}-{{version}}) | {{ cls.total }} | {{ int((cls.passed / cls.total) * 100) }}% |
     {% endfor %}
 {% endfor %}
 
@@ -18,12 +18,12 @@
 
 {% for system in systems %}
     {% for cls in system.classes %}
-## <a name="cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
+## <a name="user-content-cls-{{cls.name|lower}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
 
 | | instance | outcome | duration |
 |-|----------|---------|----------|
         {% for instance in cls.instances %}
-|{{format_outcome(instance.report.outcome)}}|[{{system.name}}.{{cls.name}}::{{instance.tag}}](#tag-{{instance.tag}}-{{version}})|{{instance.report.outcome}}|{{format_duration(instance.report.call.duration)}}|
+|{{format_outcome(instance.report.outcome)}}|[{{system.name}}.{{cls.name}}::{{instance.tag}}](#user-content-tag-{{instance.tag|lower}}-{{version}})|{{instance.report.outcome}}|{{format_duration(instance.report.call.duration)}}|
         {% endfor %}
 
     {% endfor %}
@@ -35,7 +35,7 @@
     {% for cls in system.classes %}
         {% for instance in cls.instances %}
 ---
-### <a name="tag-{{instance.tag}}-{{version}}">{{system.name}}.{{cls.name}}::{{instance.tag}}</a>
+### <a name="user-content-tag-{{instance.tag|lower}}-{{version}}">{{system.name}}.{{cls.name}}::{{instance.tag}}</a>
 
 ```
 {{ pformat(instance.instance) }}

--- a/utils/summary.tpl.md
+++ b/utils/summary.tpl.md
@@ -10,7 +10,7 @@
 |-|----------|-----------|--------------|
 {% for system in systems %}
     {% for cls in system.classes %}
-|{{format_outcome("passed" if cls.failed == 0)}}| [{{system.name}}.{{ cls.name }}](#cls-{{ cls.name }}-{{ version }}) | {{ cls.total }} | {{ int((cls.passed / cls.total) * 100) }}% |
+|{{format_outcome("passed" if cls.failed == 0)}}| [{{system.name}}.{{ cls.name }}](#user-content-cls-{{ cls.name }}-{{ version }}) | {{ cls.total }} | {{ int((cls.passed / cls.total) * 100) }}% |
     {% endfor %}
 {% endfor %}
 
@@ -18,12 +18,12 @@
 
 {% for system in systems %}
     {% for cls in system.classes %}
-## <a name="cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
+## <a name="user-content-cls-{{cls.name}}-{{version}}">{{system.name}}.{{ cls.name }}</a>
 
 | | instance | outcome | duration |
 |-|----------|---------|----------|
         {% for instance in cls.instances %}
-|{{format_outcome(instance.report.outcome)}}|[{{system.name}}.{{cls.name}}::{{instance.tag}}](#tag-{{instance.tag}}-{{version}})|{{instance.report.outcome}}|{{format_duration(instance.report.call.duration)}}|
+|{{format_outcome(instance.report.outcome)}}|[{{system.name}}.{{cls.name}}::{{instance.tag}}](#user-content-tag-{{instance.tag}}-{{version}})|{{instance.report.outcome}}|{{format_duration(instance.report.call.duration)}}|
         {% endfor %}
 
     {% endfor %}


### PR DESCRIPTION
* Only generate a report for python 3.8. Having a summary that is too long hangs the page and sometimes breaks github
* Fix anchors by appending `user-content` which is how github renders markdown anchors
* Fix anchors by making links lowercase