### PR TITLE
Remove edimburg BSS, closed 2y ago

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -767,25 +767,6 @@
             "force_https": "true"
         },
         {
-            "tag": "edinburgh-cycle-hire",
-            "meta": {
-                "latitude": 55.9411885,
-                "longitude": -3.2753783,
-                "city": "Edinburgh",
-                "name": "Just Eat Cycles",
-                "country": "UK",
-                "company": [
-                    "Your Bike",
-                    "Urban Sharing"
-                ],
-                "license": {
-                    "name": "OGL v3 license",
-                    "url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                }
-            },
-            "feed_url": "https://gbfs.urbansharing.com/edinburghcyclehire.com/gbfs.json"
-        },
-        {
           "tag": "melbourne-bike-share",
           "meta": {
               "city": "Melbourne",
@@ -827,8 +808,7 @@
                     "PBSC Urban Solutions"
                 ]
             },
-            "feed_url": "https://santiago.publicbikesystem.net/ube/gbfs/v1/",
-            "ignore_errors": true
+            "feed_url": "https://santiago.publicbikesystem.net/ube/gbfs/v1/"
         },
         {
             "tag":"oslo-bysykkel",
@@ -881,16 +861,16 @@
         {
             "tag":"velivert",
             "meta":{
-                "city":"Saint-Étienne",
-                "name":"VéliVert",
+                "city":"Saint-\u00c9tienne",
+                "name":"V\u00e9liVert",
                 "country":"FR",
                 "company": [
-                    "Fifteen"
+                    "Smoove"
                 ],
                 "latitude":45.396667,
                 "longitude":4.290833
             },
-            "feed_url":"https://api.saint-etienne-metropole.fr/velivert/api/gbfs/gbfs.json"
+            "feed_url":"https://saint-etienne-fr-smoove.klervi.net/gbfs/gbfs.json"
         },
         {
             "tag":"velopop",


### PR DESCRIPTION
Edinburg BSS are not existing anymore : https://transportforedinburgh.com/about/edinburgh-cycle-hire/