### PR TITLE
Remove Edinburg GBFS stream link (Service closed for 2 yers now)

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -767,25 +767,6 @@
             "force_https": "true"
         },
         {
-            "tag": "edinburgh-cycle-hire",
-            "meta": {
-                "latitude": 55.9411885,
-                "longitude": -3.2753783,
-                "city": "Edinburgh",
-                "name": "Just Eat Cycles",
-                "country": "UK",
-                "company": [
-                    "Your Bike",
-                    "Urban Sharing"
-                ],
-                "license": {
-                    "name": "OGL v3 license",
-                    "url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                }
-            },
-            "feed_url": "https://gbfs.urbansharing.com/edinburghcyclehire.com/gbfs.json"
-        },
-        {
           "tag": "melbourne-bike-share",
           "meta": {
               "city": "Melbourne",


### PR DESCRIPTION
BSS in Edinburg is down for 2 yers now -> https://transportforedinburgh.com/about/edinburgh-cycle-hire/