### PR TITLE
replace shapely with sympy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following dependencies are required (example using Ubuntu package manager):
 ```
 sudo apt-get install python
 sudo apt-get install python-setuptools
-sudo apt-get install libxml2 libxml2-dev libxslt1-dev libgeos-dev
+sudo apt-get install libxml2 libxml2-dev libxslt1-dev
 ```
 
 Usage

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 import requests
-from shapely.geometry import Polygon, Point, box
+from sympy import Point, Polygon
 
 from pybikes.base import BikeShareStation
 
@@ -126,17 +126,22 @@ def filter_bounds(things, key, *point_bounds):
     for pb in point_bounds:
         # Assume that a 2 length bound is a square NE/SW
         if len(pb) == 2:
-            bb = box(min(pb[0][0], pb[1][0]),
-                     min(pb[0][1], pb[1][1]),
-                     max(pb[0][0], pb[1][0]),
-                     max(pb[0][1], pb[1][1]))
-        else:
-            bb = Polygon(pb)
+            pb = [
+                # NE
+                (pb[0][0], pb[0][1]),
+                # NW
+                (pb[0][0], pb[1][1]),
+                # SW
+                (pb[1][0], pb[1][1]),
+                # SE
+                (pb[1][0], pb[0][1]),
+            ]
+        bb = Polygon(* map(Point, pb))
         bounds.append(bb)
 
     for thing in things:
         point = Point(*key(thing))
-        if not any(map(lambda pol: pol.contains(point), bounds)):
+        if not any(map(lambda pol: pol.encloses(point), bounds)):
             continue
         yield thing
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     install_requires=[
         'requests>=2.20.0',
         'lxml',
-        'shapely>=1.5.13',
+        'sympy',
     ],
 )


### PR DESCRIPTION
Fixes #538 

sympy is pure python and has no external dependencies besides mpmath which is also python