### PR TITLE
Added Bicincitta schemes

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -1525,6 +1525,58 @@
             },
             "tag": "bicimia",
             "endpoint": "https://bicimia.bresciamobilita.it"
+        },
+        {
+              "city_ids": [
+                  268
+              ],
+              "meta": {
+                  "city": "Montesilvano",
+                  "name": "Costa Blu",
+                  "country": "IT",
+                  "latitude": 42.5009,
+                  "longitude": 14.1282
+              },
+              "tag": "bicincitta-costa-blu"          
+        },
+        {
+            "city_ids": [
+                270
+            ],
+            "meta": {
+                "city": "Taranto",
+                "name": "PisTA!",
+                "country": "IT",
+                "latitude": 40.4351,
+                "longitude": 17.2096
+            },
+            "tag": "bicincitta-pista"
+        },
+        {
+            "city_ids": [
+                274
+            ],
+            "meta": {
+                "city": "Monteriggioni",
+                "name": "Sipedala",
+                "country": "IT",
+                "latitude": 43.3896,
+                "longitude": 11.2236
+            },
+            "tag": "bicincitta-monteriggioni"
+        },
+        {
+            "city_ids": [
+                275
+            ],
+            "meta": {
+                "city": "Massa",
+                "name": "Bici in Massa",
+                "country": "IT",
+                "latitude": 44.0146,
+                "longitude": 10.1017,
+            },
+            "tag": "bicincitta-massa"
         }
     ],
     "system": "bicincitta",

--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -1574,7 +1574,7 @@
                 "name": "Bici in Massa",
                 "country": "IT",
                 "latitude": 44.0146,
-                "longitude": 10.1017,
+                "longitude": 10.1017
             },
             "tag": "bicincitta-massa"
         }


### PR DESCRIPTION
There are also a number of IDs used for Weelo schemes (e.g. 277, 281, 282, 287, 288, 293, 294), however they return different (outdated?) data than the Weelo app, so I didn't include them. Would be interesting, if they work using `WeeloAPI`. Can you check? 