### PR TITLE
Revert "replace shapely with sympy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following dependencies are required (example using Ubuntu package manager):
 ```
 sudo apt-get install python
 sudo apt-get install python-setuptools
-sudo apt-get install libxml2 libxml2-dev libxslt1-dev
+sudo apt-get install libxml2 libxml2-dev libxslt1-dev libgeos-dev
 ```
 
 Usage

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 import requests
-from sympy import Point, Polygon
+from shapely.geometry import Polygon, Point, box
 
 from pybikes.base import BikeShareStation
 
@@ -125,22 +125,17 @@ def filter_bounds(things, key, *point_bounds):
     for pb in point_bounds:
         # Assume that a 2 length bound is a square NE/SW
         if len(pb) == 2:
-            pb = [
-                # NE
-                (pb[0][0], pb[0][1]),
-                # NW
-                (pb[0][0], pb[1][1]),
-                # SW
-                (pb[1][0], pb[1][1]),
-                # SE
-                (pb[1][0], pb[0][1]),
-            ]
-        bb = Polygon(* map(Point, pb))
+            bb = box(min(pb[0][0], pb[1][0]),
+                     min(pb[0][1], pb[1][1]),
+                     max(pb[0][0], pb[1][0]),
+                     max(pb[0][1], pb[1][1]))
+        else:
+            bb = Polygon(pb)
         bounds.append(bb)
 
     for thing in things:
         point = Point(*key(thing))
-        if not any(map(lambda pol: pol.encloses(point), bounds)):
+        if not any(map(lambda pol: pol.contains(point), bounds)):
             continue
         yield thing
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     install_requires=[
         'requests>=2.20.0',
         'lxml',
-        'sympy',
+        'shapely>=1.5.13',
     ],
 )


### PR DESCRIPTION
This reverts commit 7db171dbdfbf6a4cc16ff6de52b1b641263a6706.

filter_bounds takes like 3 seconds in decobike, compared to around 0.003s. using shapely. This is not surprising, and I should have known better