### PR TITLE
Kiel Sprottenflotte changed from Nextbike to Donkey Republic

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -914,6 +914,18 @@
             "feed_url": "https://stables.donkey.bike/api/public/gbfs/donkey_gh/gbfs"
         },
         {
+            "tag": "donkey-kiel",
+            "meta": {
+                "latitude": 54.2837,
+                "longitude": 10.13213,
+                "name": "Sprottenflotte",
+                "city": "Kiel",
+                "country": "DE",
+                "company": ["Donkey Republic"]
+            },
+            "feed_url": "https://stables.donkey.bike/api/public/gbfs/2/donkey_kiel/gbfs"
+        },
+        {
             "tag":"mobibikes",
             "meta":{
                 "city":"Vancouver",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -914,7 +914,7 @@
             "feed_url": "https://stables.donkey.bike/api/public/gbfs/donkey_gh/gbfs"
         },
         {
-            "tag": "donkey-kiel",
+            "tag": "sprottenflotte-kiel",
             "meta": {
                 "latitude": 54.2837,
                 "longitude": 10.13213,

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -1480,18 +1480,6 @@
             }
         },
         {
-            "domain": "sf",
-            "tag": "sprottenflotte-kiel",
-            "city_uid": 613,
-            "meta": {
-                "name": "Sprottenflotte",
-                "city": "Kiel",
-                "country": "DE",
-                "latitude": 54.2837,
-                "longitude": 10.13213
-            }
-        },
-        {
             "domain": "sl",
             "tag": "alsa-nextbike-leon",
             "city_uid": 701,


### PR DESCRIPTION
Operator changed in Kiel see sprottenflotte.de or https://www.donkey.bike/de/stadte/kiel/