### PR TITLE
Add Docomo Tokyo Bike Share

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -988,6 +988,20 @@
                 "longitude": -110.9749
             },
             "feed_url": "https://tucson.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
+        },
+        {
+            "tag": "docomo-cycle-tokyo",
+            "meta": {
+                "city": "Tokyo",
+                "name": "Docomo Bike Share Tokyo",
+                "country": "JP",
+                "company": [
+                    "DOCOMO BIKE SHARE, INC"
+                ],
+                "latitude": 35.6827,
+                "longitude": 139.7660
+            },
+            "feed_url": "https://api-public.odpt.org/api/v4/gbfs/docomo-cycle-tokyo/gbfs.json"
         }
     ],
     "system": "gbfs",


### PR DESCRIPTION
GBFS feed comes from ODPT, a Japanese public transport platform: https://ckan.odpt.org/dataset/c_bikeshare_gbfs-d-bikeshare.

Closes https://github.com/eskerda/pybikes/issues/286.