### PR TITLE
[gbfs] add configurable cache deltas for feeds

### DIFF
--- a/pybikes/contrib.py
+++ b/pybikes/contrib.py
@@ -34,9 +34,14 @@ class TSTCache(dict):
             raise KeyError('%s' % key)
         if key not in self.store:
             raise KeyError('%s' % key)
+
         ts_value = self.store[key]
-        if time.time() - ts_value['ts'] > self.delta:
+        the_time = time.time()
+        delta = ts_value.get('delta', self.delta)
+
+        if the_time - ts_value['ts'] > delta:
             raise KeyError('%s' % key)
+
         return ts_value['value']
 
     def __contains__(self, key):
@@ -58,3 +63,11 @@ class TSTCache(dict):
 
     def __transform_key__(self, key):
         return key
+
+    def set_with_delta(self, key, value, delta):
+        """ Set a key-value with a specific delta """
+        self.store[key] = {
+            'value': value,
+            'ts': time.time(),
+            'delta': delta,
+        }

--- a/pybikes/deutschebahn.py
+++ b/pybikes/deutschebahn.py
@@ -14,6 +14,18 @@ FEED_URL = 'https://apis.deutschebahn.com/db-api-marketplace/apis/shared-mobilit
 class DB(Gbfs):
     authed = True
 
+    cache = True
+    cache_deltas = {
+        # 12 hours
+        'gbfs': 12 * 60 * 60,
+        # 1 hour
+        'station_information': 60 * 60,
+        # 60 seconds
+        'station_status': 60,
+        # 12 hours
+        'vehicle_types': 12 * 60 * 60,
+    }
+
     meta = {
         'company': ['Deutsche Bahn AG'],
         'system': 'deutschebahn',
@@ -52,12 +64,5 @@ class Callabike(DB):
 
     provider = 'CallABike'
 
-    # caches the feed for 60s
-    cache = TSTCache(delta=60)
-
     def __init__(self, * args, ** kwargs):
         super(Callabike, self).__init__(* args, provider=Callabike.provider, ** kwargs)
-
-    def update(self, scraper=None):
-        scraper = scraper or PyBikesScraper(self.cache)
-        super(Callabike, self).update(scraper)

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -60,7 +60,7 @@ class BaseInstanceTest(object):
     def test_update(self, instance, i_data, cls, mod, record_property):
         scraper = pybikes.PyBikesScraper(
             # use a simple dict cache for systems that use a single endpoint
-            cachedict=cache if instance.unifeed else None,
+            cachedict=cache if (instance.unifeed or instance.cache) else None,
             # reuse headers per mod
             headers=headers.setdefault(mod, {}),
         )


### PR DESCRIPTION
Current gbfs implementation does 4 requests per update on a worst case scenario. Gbfs is as it is by design, but we can try to make it a bit easier on the servers by adding a particular delta on specific parts of the feed that do not change that often, like station_information, vehicle_types or the main gbfs index response.