### PR TITLE
fix(velib): change gbfs url

### DIFF
--- a/pybikes/data/velib.json
+++ b/pybikes/data/velib.json
@@ -14,7 +14,7 @@
                 },
                 "ebikes": true
             },
-            "feed_url": "https://velib-metropole-opendata.smoove.pro/opendata/Velib_Metropole/gbfs.json"
+            "feed_url": "https://velib-metropole-opendata.smovengo.cloud/opendata/Velib_Metropole/gbfs.json"
         }
     ],
     "system": "velib",


### PR DESCRIPTION
The GBFS url for Velib (Paris) has changed since 26 September 2023 (see [Velib website](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole))
Here is the new one -> [new gbfs url](https://velib-metropole-opendata.smovengo.cloud/opendata/Velib_Metropole/gbfs.json)