### PR TITLE
Update setup-python action

### DIFF
--- a/.github/workflows/test_python2.yml
+++ b/.github/workflows/test_python2.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 2.7
-      uses: MatteoH2O1999/setup-python@v1
+      uses: MatteoH2O1999/setup-python@v3
       with:
         python-version: '2.7'
         allow-build: info


### PR DESCRIPTION
The Python 2.7 CI is [failing](https://github.com/eskerda/pybikes/actions/runs/7200695547/job/19615199208) due to a mirror being out of date. The [new version](https://github.com/MatteoH2O1999/build-and-install-python/blame/master/src/builder/linux.ts#L119) of the [setup-python](https://github.com/MatteoH2O1999/setup-python) action should make sure the repositories are up-to-date before running `apt-get install`. 