### PR TITLE
Add Zoov network in Saclay/Grand-Paris (FR)

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1141,6 +1141,27 @@
             "station_status": "https://gateway.prod.partners-fs37hd8.zoov.site/gbfs/2.2/landerneau/en/station_status.json?&key=M2RjMTgyODYtZDM0OS00NjI0LWJiMjMtYzhmYjVlMDI0MzM0"
         },
         {
+            "tag": "zoov-paris-sud",
+            "meta": {
+                "city": "Saclay",
+                "name": "Zoov",
+                "country": "FR",
+                "company": [
+                    "Fifteen SAS"
+                ],
+                "latitude": 48.7307,
+                "longitude": 2.1742,
+                "source": "https://www.data.gouv.fr/fr/datasets/r/4646ba01-4fe0-4cd8-91d3-09e204bbaf86",
+                "license": {
+                    "name": "Open Data Commons Open Database License (ODbL)",
+                    "url": "http://opendatacommons.org/licenses/odbl/summary/"
+                }
+            },
+            "feed_url": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/gbfs.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "station_information": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_information.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "station_status": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_status.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1"
+        },
+        {
             "tag": "velopartage-geneve",
             "meta": {
                 "city": "Genève",


### PR DESCRIPTION
Hello,

Please take a look at this Pull Request to add a system called "Zoov" in France.

The feed URL and authentication key have been taken from the following link (under "see metdata") : https://www.data.gouv.fr/fr/datasets/paris-sud-velos-a-assistance-electrique-en-libre-service

As the area of "Paris Sud" is spread across many cities, I set the "City" name to "Saclay" because of the URL of the feed ("gbfs/2.2/saclay/en").

Note: All of this system's bikes are electrical bikes. It would have been interesting to set the "ebikes" extra field in pybikes. I saw that for GBFS feeds this is done when the "num_ebikes_available" field is provided by the feed (in station_status.json). Unfortunately, the feed does not specifiy this entry. That's a shame but I beleive it should be the responsability of the remote feed to complains to the GBFS standard.

Thank you for the project.
Regards.