### PR TITLE
fix gbfs vehicles

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1159,7 +1159,8 @@
             },
             "feed_url": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/gbfs.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
             "station_information": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_information.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
-            "station_status": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_status.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1"
+            "station_status": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/station_status.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1",
+            "vehicle_types": "https://gateway.prod.zoov.io/gbfs/2.2/saclay/en/vehicle_types.json?key=NGFlMjU3MDUtNDk5My00MTM4LTk1ZjctNmNlNDM1MWQ0NjE1"
         },
         {
             "tag": "velopartage-geneve",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1143,14 +1143,14 @@
         {
             "tag": "zoov-paris-sud",
             "meta": {
-                "city": "Saclay",
+                "city": "Paris Sud",
                 "name": "Zoov",
                 "country": "FR",
                 "company": [
                     "Fifteen SAS"
                 ],
-                "latitude": 48.7307,
-                "longitude": 2.1742,
+                "latitude": 48.7429,
+                "longitude": 2.2380,
                 "source": "https://www.data.gouv.fr/fr/datasets/r/4646ba01-4fe0-4cd8-91d3-09e204bbaf86",
                 "license": {
                     "name": "Open Data Commons Open Database License (ODbL)",

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -33,6 +33,7 @@ class Gbfs(BikeShareSystem):
         force_https=False,
         station_information=False,
         station_status=False,
+        vehicle_types=False,
         ignore_errors=False,
         retry=None,
         bbox=None,
@@ -53,6 +54,9 @@ class Gbfs(BikeShareSystem):
 
         if station_status:
             self.feeds['station_status'] = station_status
+
+        if vehicle_types:
+            self.feeds['vehicle_types'] = vehicle_types
 
     @property
     def default_feeds(self):


### PR DESCRIPTION
This PR adds an option to gbfs parser to hardcode vehicle type URLs. Also fixes an issue on the gbfs vehicle parser overwriting numbers when updating the data in extra. It now merges data but adds existing keys if the value is an integer (such as number of bikes).

This is related to https://github.com/eskerda/pybikes/pull/661#issuecomment-1871262844 (@francoisfds)

Also sets `zoov-paris-sud` city to `Paris Sud`. Even if it's not a city it seems a zone name worth using.

> Géolocalisation en temps réel des vélos à assistance électrique partagés du service Zoov by Fifteen dans la zone Paris Sud, comprenant les communes Saint-Rémy-lès-Chevreuse, Bourg-la-Reine, Massy, Palaiseau, Vauhallan, Jouy-en-Josas, Villebon-sur-Yvette, Igny, Le Plessis-Robinson, Antony, Sceaux, Saclay, Fontenay-aux-Roses, Bures-sur-Yvette, Verrières-le-Buisson, Orsay, Gif-sur-Yvette, Saint-Aubin, et Les Ulis.

Now the feed shows correct ebike numbers:

<img width="1497" alt="image" src="https://github.com/eskerda/pybikes/assets/208952/e51e7aa4-abec-443c-a290-b56835f05e10">
