### PR TITLE
GBFS fixes and improvements

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -779,6 +779,7 @@
                 "latitude": 4.6569,
                 "longitude": -74.0656
             },
+            "bbox": [[4.719375734803037, -74.02234088704458], [4.588374427629375, -74.0977190296218]],
             "feed_url": "https://bogota.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         },
         {

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -78,6 +78,16 @@ class Gbfs(BikeShareSystem):
             station.extra['ebikes'] += vehicle['count']
             station.extra['has_ebikes'] = True
 
+        def update_ecargo(station, vehicle, info):
+            station.extra.setdefault('ecargo', 0)
+            station.extra['ecargo'] += vehicle['count']
+            station.extra['has_ecargo'] = True
+
+        def update_cargo(station, vehicle, info):
+            station.extra.setdefault('cargo', 0)
+            station.extra['cargo'] += vehicle['count']
+            station.extra['has_cargo'] = True
+
         # contains pairs of (vehicle query, resolver)
         return [
             (
@@ -87,6 +97,15 @@ class Gbfs(BikeShareSystem):
             (
                 lambda v: v['propulsion_type'] in ['electric_assist', 'electric'] and v['form_factor'] == 'bicycle',
                 update_ebikes
+            ),
+            (
+                lambda v: v['propulsion_type'] == 'human' and v['form_factor'] == 'cargo_bicycle',
+                update_cargo
+            ),
+
+            (
+                lambda v: v['propulsion_type'] == 'electric_assist' and v['form_factor'] == 'cargo_bicycle',
+                update_ecargo
             ),
         ]
 

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -164,7 +164,21 @@ class Gbfs(BikeShareSystem):
             (station_information[uid], station_status[uid])
             for uid in station_information.keys()
         )
+
+        # Filter station by bbox before parsing and appending to a list.
+        # Some networks have a LOT of stations
+        if self.bbox:
+            def getter(zipinfo):
+                info, status = zipinfo
+                # some networks break spec by setting lat and lng in status
+                lat = info.get('lat') or status.get('lat')
+                lng = info.get('lon') or status.get('lon')
+                return (lat, lng)
+
+            station_zip = filter_bounds(station_zip, getter, self.bbox)
+
         stations = []
+
         for info, status in station_zip:
             # Some feeds have info keys set to none on status
             info.update({k: v for k, v in status.items() if v is not None})
@@ -178,9 +192,6 @@ class Gbfs(BikeShareSystem):
                 raise e
 
             stations.append(station)
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -160,10 +160,10 @@ class Gbfs(BikeShareSystem):
         station_information = {s['station_id']: s for s in station_information}
         station_status = {s['station_id']: s for s in station_status}
         # Any station not in station_information will be ignored
-        station_zip = [
+        station_zip = (
             (station_information[uid], station_status[uid])
             for uid in station_information.keys()
-        ]
+        )
         stations = []
         for info, status in station_zip:
             # Some feeds have info keys set to none on status


### PR DESCRIPTION
* Filter stations before parsing them: Some gbfs systems have a lot of stations, like hellocycling. Filtering before parsing stations should reduce both memory and cpu footprint. Probably negligible, but better safe on this case

* Fix an error handling unsupported vehicles. https://github.com/eskerda/pybikes/pull/665 introduced a bug when trying to parse unhandled vehicles. This PR fixes the noop parser, and also throws a useful warning to discover interesting vehicle types
* Add support for cargo and ecargo vehicles: found a couple of systems announcing these: `sprottenflotte`, `foli` and `neuchatelroule`
* There were some test stations in `tembici-bogota` with many unsupported vehicles and crazy numbers. This bug made these surface. Added a bbox to filter these test stations anyway.