### PR TITLE
Automatic bbox filtering

### DIFF
--- a/pybikes/aksu.py
+++ b/pybikes/aksu.py
@@ -6,16 +6,15 @@ import re
 import json
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 
-class Aksu(BikeShareSystem):
+class Aksu(Bounded, BikeShareSystem):
     unifeed = True
 
     def __init__(self, tag, meta, endpoint, bbox=None):
-        super(Aksu, self).__init__(tag, meta)
+        super(Aksu, self).__init__(tag, meta, bounds=bbox)
         self.endpoint = endpoint
-        self.bbox = bbox
 
     def update(self, scraper=None):
         scraper = scraper or PyBikesScraper()
@@ -29,9 +28,6 @@ class Aksu(BikeShareSystem):
 
         for station in markers["station"]:
             stations.append(AksuStation(station))
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/bicing.py
+++ b/pybikes/bicing.py
@@ -2,21 +2,20 @@
 import json
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
+from pybikes.utils import Bounded
 from pybikes.exceptions import InvalidStation
-from pybikes.utils import filter_bounds
 
 STATIONS_URL = '{endpoint}/get-stations'
 
 
-class Bicing(BikeShareSystem):
+class Bicing(Bounded, BikeShareSystem):
     meta = {
         'ebikes': True,
     }
 
     def __init__(self, tag, meta, endpoint, bbox=None):
-        super(Bicing, self).__init__(tag, meta)
+        super(Bicing, self).__init__(tag, meta, bounds=bbox)
         self.endpoint = endpoint
-        self.bbox = bbox
 
     @property
     def stations_url(self):
@@ -35,9 +34,6 @@ class Bicing(BikeShareSystem):
             except InvalidStation:
                 continue
             stations.append(station)
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/decobike.py
+++ b/pybikes/decobike.py
@@ -5,10 +5,10 @@
 from lxml import etree
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 
-class DecoBike(BikeShareSystem):
+class DecoBike(Bounded, BikeShareSystem):
     sync = True
 
     meta = {
@@ -25,9 +25,8 @@ class DecoBike(BikeShareSystem):
     }
 
     def __init__(self, tag, meta, feed_url, bbox=None):
-        super(DecoBike, self).__init__(tag, meta)
+        super(DecoBike, self).__init__(tag, meta, bounds=bbox)
         self.feed_url = feed_url
-        self.bbox = bbox
 
     def update(self, scraper=None):
         scraper = scraper or PyBikesScraper()
@@ -51,8 +50,5 @@ class DecoBike(BikeShareSystem):
             }
 
             stations.append(station)
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations

--- a/pybikes/easybike.py
+++ b/pybikes/easybike.py
@@ -7,15 +7,15 @@
 
 import json
 
-from pybikes.base import BikeShareSystem, BikeShareStation
-from pybikes import utils
+from pybikes import BikeShareSystem, BikeShareStation
+from pybikes.utils import PyBikesScraper, Bounded
 
 
 class BaseSystem(BikeShareSystem):
     meta = {"system": "EasyBike", "company": ["Brainbox Technology", "Smoove SAS"]}
 
 
-class EasyBike(BaseSystem):
+class EasyBike(Bounded, BaseSystem):
     sync = True
     unifeed = True
 
@@ -27,19 +27,16 @@ class EasyBike(BaseSystem):
     feed_url = 'http://reseller.easybike.gr/{city_uid}/api.php'
 
     def __init__(self, tag, meta, city_uid, bbox=None):
-        super(EasyBike, self).__init__(tag, meta)
+        super(EasyBike, self).__init__(tag, meta, bounds=bbox)
         self.feed_url = EasyBike.feed_url.format(city_uid=city_uid)
-        self.bbox = bbox
 
     def update(self, scraper=None):
-        scraper = scraper or utils.PyBikesScraper()
+        scraper = scraper or PyBikesScraper()
 
         stations = []
 
         data = json.loads(scraper.request(self.feed_url))
         stations = self.get_stations(data)
-        if self.bbox:
-            stations = utils.filter_bounds(stations, None, self.bbox)
         self.stations = list(stations)
 
     def get_stations(self, data):
@@ -66,8 +63,7 @@ class EasyBikeNew(BaseSystem):
         self.city_uid = city_uid
 
     def update(self, scraper=None):
-        if scraper is None:
-            scraper = utils.PyBikesScraper()
+        scraper = scraper or PyBikesScraper()
 
         data = json.loads(
             scraper.request(

--- a/pybikes/joco.py
+++ b/pybikes/joco.py
@@ -4,14 +4,13 @@
 import json
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 
-class Joco(BikeShareSystem):
+class Joco(Bounded, BikeShareSystem):
     def __init__(self, tag, meta, bbox, feed_url):
-        super(Joco, self).__init__(tag, meta)
+        super(Joco, self).__init__(tag, meta, bounds=bbox)
 
-        self.bbox = bbox
         self.feed_url = feed_url
 
     def update(self, scraper=None):
@@ -22,9 +21,6 @@ class Joco(BikeShareSystem):
 
         for station in data:
             stations.append(JocoStation(station))
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/kolumbus.py
+++ b/pybikes/kolumbus.py
@@ -5,20 +5,20 @@
 import json
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 
 BASE_URL = 'https://kolumbus-sanntidsskjerm-backend-prod.azurewebsites.net/sanntidapi/parkings/status'
 
 
-class Kolumbus(BikeShareSystem):
+class Kolumbus(Bounded, BikeShareSystem):
     meta = {
         'system': 'kolumbus',
         'company': ['Kolumbus']
     }
 
     def __init__(self, tag, meta, bbox):
-        super(Kolumbus, self).__init__(tag, meta)
+        super(Kolumbus, self).__init__(tag, meta, bounds=bbox)
         self.bbox = bbox
 
     def update(self, scraper=None):
@@ -29,9 +29,6 @@ class Kolumbus(BikeShareSystem):
         stations = []
         for station in data:
             stations.append(KolumbusStation(station))
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/samba.py
+++ b/pybikes/samba.py
@@ -5,7 +5,7 @@
 # Distributed under the LGPL license, see LICENSE.txt
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 import re
 import ast
@@ -13,16 +13,15 @@ import ast
 USERAGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/31.0.1650.63 Chrome/31.0.1650.63 Safari/537.36"  # NOQA
 
 
-class Samba(BikeShareSystem):
+class Samba(Bounded, BikeShareSystem):
     meta = {
         'system': 'Samba',
         'company': ['Mobilicidade Tecnologia LTD', 'Grupo Serttel LTDA']
     }
 
     def __init__(self, tag, meta, url, bbox=None):
-        super(Samba, self).__init__(tag, meta)
+        super(Samba, self).__init__(tag, meta, bounds=bbox)
         self.feed_url = url
-        self.bbox = bbox
 
     def update(self, scraper=None):
         if scraper is None:
@@ -38,9 +37,6 @@ class Samba(BikeShareSystem):
 
         for station in stations_data:
             stations.append(SambaStation(station))
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -23,7 +23,6 @@ class PyBikesScraper(object):
     last_request = None
     requests_timeout = 300
     retry = False
-    retry_opts = {}
 
     def __init__(self, cachedict=None, headers=None):
         self.headers = headers if isinstance(headers, dict) else {}
@@ -31,6 +30,7 @@ class PyBikesScraper(object):
         self.proxies = {}
         self.session = requests.session()
         self.cachedict = cachedict
+        self.retry_opts = {}
 
     def setUserAgent(self, user_agent):
         self.headers['User-Agent'] = user_agent

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -15,7 +15,7 @@ import requests
 from requests.adapters import HTTPAdapter, Retry
 from shapely.geometry import Point, box, shape
 
-from pybikes.base import BikeShareStation
+from pybikes.base import BikeShareSystem, BikeShareStation
 
 
 class PyBikesScraper(object):
@@ -133,6 +133,29 @@ def filter_bounds(things, key, *point_bounds):
         if not any(map(lambda pol: pol.contains(point), bounds)):
             continue
         yield thing
+
+
+class Bounded:
+    """ Class mixin providing automatic bound filtering to stations """
+    bounds = None
+    _stations = None
+
+    def __init__(self, * args, ** kwargs):
+        self._stations = []
+        self.bounds = kwargs.pop('bounds', None)
+        super(Bounded, self).__init__(* args, ** kwargs)
+
+    @property
+    def stations(self):
+        return self._stations
+
+    @stations.setter
+    def stations(self, value):
+        # XXX: note that any list method applied to self.stations will
+        # circumvent this method (such as append)
+        if self.bounds:
+            value = list(filter_bounds(value, None, self.bounds))
+        self._stations = value
 
 
 class Keys:

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -135,7 +135,7 @@ def filter_bounds(things, key, *point_bounds):
         yield thing
 
 
-class Bounded:
+class Bounded(object):
     """ Class mixin providing automatic bound filtering to stations """
     bounds = None
     _stations = None

--- a/pybikes/wegoshare.py
+++ b/pybikes/wegoshare.py
@@ -5,7 +5,7 @@
 import json
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 STATIONS_URL = '{endpoint}/cxf/am/station/map/search'
 FILES_URL = '{endpoint}/cxf/fm/files/{file_id}'
@@ -15,7 +15,7 @@ def file_url(endpoint, file_id):
     return FILES_URL.format(endpoint=endpoint, file_id=file_id)
 
 
-class WeGoShare(BikeShareSystem):
+class WeGoShare(Bounded, BikeShareSystem):
     headers = {
         'Content-Type': 'application/json; charset=utf-8',
     }
@@ -26,9 +26,8 @@ class WeGoShare(BikeShareSystem):
 
     def __init__(self, tag, meta, endpoint, bbox=None):
         meta['company'] += WeGoShare.meta['company']
-        super(WeGoShare, self).__init__(tag, meta)
+        super(WeGoShare, self).__init__(tag, meta, bounds=bbox)
         self.endpoint = endpoint
-        self.bbox = bbox
 
     @property
     def stations_url(self):
@@ -48,9 +47,6 @@ class WeGoShare(BikeShareSystem):
                 continue
             station = WeGoShareStation(station_data, self.endpoint)
             stations.append(station)
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/pybikes/yelovelo.py
+++ b/pybikes/yelovelo.py
@@ -5,16 +5,15 @@
 import json
 
 from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
-from pybikes.utils import filter_bounds
+from pybikes.utils import Bounded
 
 
 FEED_URL = 'https://opendata.agglo-larochelle.fr/d4c/api/records/2.0/downloadfile/format=json&resource_id=1f124bea-d55f-457f-9eab-b7877d803435'
 
 
-class YeloVelo(BikeShareSystem):
+class YeloVelo(Bounded, BikeShareSystem):
     def __init__(self, tag, meta, bbox=None):
-        super(YeloVelo, self).__init__(tag, meta)
-        self.bbox = bbox
+        super(YeloVelo, self).__init__(tag, meta, bounds=bbox)
 
     def update(self, scraper=None):
         if scraper is None:
@@ -26,9 +25,6 @@ class YeloVelo(BikeShareSystem):
         for station_data in stations_data:
             station = YeloVeloStation(station_data)
             stations.append(station)
-
-        if self.bbox:
-            stations = list(filter_bounds(stations, None, self.bbox))
 
         self.stations = stations
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ from pkg_resources import resource_string
 
 import pytest
 
-from pybikes import BikeShareStation
-from pybikes.utils import filter_bounds
+from pybikes import BikeShareSystem, BikeShareStation
+from pybikes.utils import filter_bounds, Bounded
 
 barcelona = [
     BikeShareStation(latitude=41.38530363280023, longitude=2.1537750659833534),
@@ -123,3 +123,37 @@ filter_bounds_cases = [
 @pytest.mark.parametrize("msg, data, expected, getter, bounds", filter_bounds_cases)
 def test_filter_bounds(msg, data, expected, getter, bounds):
     assert expected == list(filter_bounds(data, getter, bounds)), msg
+
+
+class TestBounded:
+
+    class BoundsSystem(Bounded, BikeShareSystem):
+        pass
+
+    def test_with_no_bounds(self):
+        tag = 'foo'
+        meta = {'name': 'Foo', 'system': 'Foo'}
+        bbox = None
+        foo = TestBounded.BoundsSystem(tag, meta, bounds=bbox)
+        foo.stations = [
+            (41.3853036328, 2.1537750659833534),
+            (31.3853036328, 1.1537750659833534),
+        ]
+        assert [
+            (41.3853036328, 2.1537750659833534),
+            (31.3853036328, 1.1537750659833534),
+        ] == foo.stations
+
+
+    def test_with_bounds(self):
+        tag = 'foo'
+        meta = {'name': 'Foo', 'system': 'Foo'}
+        bbox = [[41.429655489542995, 2.265798843028506], [41.324098007178094, 2.060483133624132]]
+        foo = TestBounded.BoundsSystem(tag, meta, bounds=bbox)
+        foo.stations = [
+            (41.3853036328, 2.1537750659833534),
+            (31.3853036328, 1.1537750659833534),
+        ]
+        assert [
+            (41.3853036328, 2.1537750659833534),
+        ] == foo.stations


### PR DESCRIPTION
This PR adds an utility class that magically filters by a bbox or bounds argument.

We have many systems that use the same boilerplate for filterting bounds. Not all cases are the same, for instance on gbfs and nextbike we prefilter before parsing the stations. For the general usecase, this utility class is the best of both worlds.

I have decided against adding it to the base class itself because of unexpected behaviors using properties. We could set a flag over at the class, like `disable_bbox_filtering`, but having that flag (undocumented) would probably be less explicit than using an utility class.

Let me know what you think