### PR TITLE
PubliBike (CH): count number of ebikes at station

### DIFF
--- a/pybikes/publibike.py
+++ b/pybikes/publibike.py
@@ -62,6 +62,10 @@ class PublibikeStation(BikeShareStation):
             'zip': station['zip'],
             'city': station['city'],
             'slots': station['capacity'],
+            'ebikes': 0,
         }
+        for vehicle in station['vehicles']:
+            if (vehicle['type']['id'] == 2):
+                self.extra['ebikes'] += 1
         self.bikes = len(station['vehicles'])
         self.free = self.extra['slots'] - self.bikes


### PR DESCRIPTION
This counts the number of ebikes at a given station and adds the count to the extra field.

In the PubliBike API, a vehicle gets ID = 1 if it's a simple bike and ID = 2 if it's an ebike.