### PR TITLE
Remove Erlagen and Getxo systems

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -2623,18 +2623,6 @@
             }
         },
         {
-            "domain": "er",
-            "tag": "nextbike-erlangen",
-            "city_uid": 829,
-            "meta": {
-                "name": "nextbike Erlangen",
-                "city": "Erlangen",
-                "country": "DE",
-                "latitude": 49.589,
-                "longitude": 11.0065
-            }
-        },
-        {
             "domain": "cd",
             "tag": "nomago-gorizia",
             "city_uid": 771,
@@ -2697,23 +2685,6 @@
                 "longitude": -0.4182,
                 "company": [
                     "Movilidad Urbana Sostenible, S.L"
-                ]
-            }
-        },
-        {
-            "domain": "ex",
-            "tag": "getxobizi",
-            "city_uid": 749,
-            "meta": {
-                "name": "Getxobizi",
-                "city": "Getxo",
-                "country": "ES",
-                "latitude": 43.3476,
-                "longitude": -3.0088,
-                "company": [
-                    "UTE TIER",
-                    "Mobility SE",
-                    "Empresa Sagales SA GETXOBIZI"
                 ]
             }
         },


### PR DESCRIPTION
Erlagen is gone and will be administered by VAG_Rad:
https://github.com/MobilityData/gbfs/pull/581

Getxobizi is now Bizkaibizi:
https://www.elcorreo.com/bizkaia/margen-derecha/llegada-servicio-foral-bicicletas-pone-fin-getxobizi-20231019193110-nt.html