### PR TITLE
Add Santander TUeBICI

### DIFF
--- a/pybikes/data/cyclocity.json
+++ b/pybikes/data/cyclocity.json
@@ -48,17 +48,6 @@
                     "contract": "Lund"
                 },
                 {
-                    "tag": "tusbic",
-                    "meta": {
-                        "latitude": 43.46230569999999,
-                        "country": "ES",
-                        "name": "Tusbic",
-                        "longitude": -3.8099803,
-                        "city": "Santander"
-                    },
-                    "contract": "Santander"
-                },
-                {
                     "tag": "velam",
                     "meta": {
                         "latitude": 49.894067,

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -2746,6 +2746,21 @@
                     "Movilidad Urbana Sostenible S.L."
                 ]
             }
+        },
+        {
+            "domain": "ek",
+            "tag": "tuebici",
+            "city_uid": 914,
+            "meta": {
+                "name": "TUeBICI",
+                "city": "Santander",
+                "country": "ES",
+                "latitude": 43.46230569999999,
+                "longitude": -3.8099803,
+                "company": [
+                    "UTE BICIS SANTANDER"
+                ]
+            }
         }
     ],
     "system": "nextbike",


### PR DESCRIPTION
Just opened: https://www.eldiario.es/cantabria/ultimas-noticias/usuarios-tuebici-deberan-devolver-bici-horas-alquiler-no-hay-limite-usos-diarios_1_10805248.html