### PR TITLE
Add Vélozef, Brest

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1151,6 +1151,24 @@
                 ]
             },
             "feed_url": "https://pittsburgh.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
+        },
+        {
+            "tag": "velozef",
+            "meta": {
+                "latitude": 48.3905,
+                "longitude": -4.48732,
+                "city": "Brest",
+                "name": "VéloZef",
+                "country": "FR",
+                "company": [
+                    "Fifteen SAS"
+                ],
+                "source": "https://www.data.gouv.fr/fr/datasets/velos-a-assistance-electrique-en-libre-service-velozef-sur-brest/"
+            },
+            "feed_url": "https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/gbfs.json?&key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx",
+            "station_information": "https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/station_information.json?&key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx",
+            "station_status": "https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/station_status.json?&key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx",
+            "vehicle_types": "https://api.prod.partners-fs37hd8.zoov.eu/gbfs/2.2/brest/en/vehicle_types.json?&key=OGNhZDNjMDQtYTA0Yi00NzU2LWE0MTItOGJlYzE1Y2E4NGEx"
         }
     ],
     "system": "gbfs",


### PR DESCRIPTION
https://www.data.gouv.fr/fr/datasets/velos-a-assistance-electrique-en-libre-service-velozef-sur-brest/#/resources