### PR TITLE
Add ebike field to bcycle

### DIFF
--- a/pybikes/bcycle.py
+++ b/pybikes/bcycle.py
@@ -2,13 +2,25 @@
 # Copyright (C) 2023, Martín González Gómez <m@martingonzalez.net>
 # Distributed under the AGPL license, see LICENSE.txt
 
-from pybikes.gbfs import Gbfs
+from pybikes.gbfs import Gbfs, GbfsStation
 
 
 FEED_URL = "https://gbfs.bcycle.com/{uid}/gbfs.json"
 
+class BCycleStation(GbfsStation):
+
+    def __init__(self, info, * args, ** kwargs):
+        super(BCycleStation, self).__init__(info, * args, ** kwargs)
+
+        # similar as velib, ebikes are listed under num_bikes_available_types
+        # https://github.com/eskerda/pybikes/blob/master/pybikes/velib.py#L17-L20
+        self.extra['has_ebikes'] = True
+        self.extra['ebikes'] = int(info['num_bikes_available_types']['electric'])
+        self.extra['normal_bikes'] = int(info['num_bikes_available_types']['classic'])
+
 
 class BCycle(Gbfs):
+    station_cls = BCycleStation
     meta = {"system": "BCycle", "company": ["BCycle, LLC"]}
 
     def __init__(self, tag, meta, uid, bbox=None):


### PR DESCRIPTION
Add a specific ebike parser for Bcycle. There's also an unused `smart` field (https://gbfs.bcycle.com/bcycle_indego/station_status.json).

I don't see `num_bikes_available_types` in the [GBFS v1.1. specification](https://github.com/MobilityData/gbfs/blob/v1.1/gbfs.md) but all the Bcycle systems seem to use this.

Close https://github.com/eskerda/pybikes/issues/714.