### PR TITLE
Cristolib network is closed

### DIFF
--- a/pybikes/data/cyclocity.json
+++ b/pybikes/data/cyclocity.json
@@ -136,17 +136,6 @@
                     "contract": "Nancy"
                 },
                 {
-                    "tag": "cristolib",
-                    "meta": {
-                        "latitude": 48.790367,
-                        "country": "FR",
-                        "name": "Cristolib",
-                        "longitude": 2.455572,
-                        "city": "Cr\u00e9teil"
-                    },
-                    "contract": "Creteil"
-                },
-                {
                     "tag": "villo",
                     "meta": {
                         "latitude": 50.8503396,


### PR DESCRIPTION
The "Cristolib" network (France) is definitely closed since 2024-05-20.

See these links (only in french) :
- http://www.cristolib.fr/misc/closed.html (could go offline at some point)
- https://www.ville-creteil.fr/fermeture-definitive-du-service-cristolib

This pull request removes the network from pybikes.

Regards.