### PR TITLE
Add two Soltráfego bike sharing systems

### DIFF
--- a/pybikes/data/soltrafego.json
+++ b/pybikes/data/soltrafego.json
@@ -29,7 +29,7 @@
                 "city": "CIM Viseu Dão-Lafões",
                 "country": "PT",
                 "latitude": 40.656392,
-                "longitude": -7.912545
+                "longitude": -7.912545,
                 "name": "Bora!"
             },
             "tag": "bora"

--- a/pybikes/data/soltrafego.json
+++ b/pybikes/data/soltrafego.json
@@ -11,7 +11,29 @@
                 "name": "BUGA"
             },
             "tag": "buga"
-        }
+        },
+        {
+            "uid": "13fe90d9a574fe5346914d76fee8466d711db3cd",
+            "meta": {
+                "city": "Pombal",
+                "country": "PT",
+                "latitude": 39.915278,
+                "longitude": -8.632222,
+                "name": "Pombike"
+            },
+            "tag": "pombike"
+        },
+        {
+            "uid": "d02d3e4962abd7483727c2ba12d253bc2d06c225",
+            "meta": {
+                "city": "CIM Viseu Dão-Lafões",
+                "country": "PT",
+                "latitude": 40.656392,
+                "longitude": -7.912545
+                "name": "Bora!"
+            },
+            "tag": "bora"
+        },
     ],
     "system": "soltrafego"
 }

--- a/pybikes/data/soltrafego.json
+++ b/pybikes/data/soltrafego.json
@@ -33,7 +33,7 @@
                 "name": "Bora!"
             },
             "tag": "bora"
-        },
+        }
     ],
     "system": "soltrafego"
 }


### PR DESCRIPTION
Adds Pombike (Pombal) and Bora! (CIM Viseu Dão-Lafões) bikesharing systems. The last one is not yet available but apparently scheduled to be very soon.

There are a bunch other systems using the same provider (Soltráfego) but the endpoint you're using is built for the iframes embedded in each system's website, so the `uid` being used seems to actually be the id of the frame.
Some of them chose not to include that iframe in their websites.

There's another endpoint that allows for the same data to be obtained for every one of the systems supported by this provider. I'm working on those changes, but for now here's these two.

I love this project! 🚀 