### PR TITLE
Remove veloceo (Vannes, FR)

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -474,20 +474,6 @@
             "feed_url": "https://monaco.publicbikesystem.net/customer/ube/gbfs/v1/"
         },
         {
-            "tag": "veloceo",
-            "meta": {
-                "city": "Vannes",
-                "name": "Vélocéo",
-                "country": "FR",
-                "company": [
-                    "Smoove"
-                ],
-                "latitude": 47.6559,
-                "longitude": -2.7603
-            },
-            "feed_url": "https://vannes-gbfs.klervi.net/gbfs/gbfs.json"
-        },
-        {
             "tag": "mibicitubici",
             "meta": {
               "city": "Rosario",


### PR DESCRIPTION
The service has been stopped: https://actu.fr/bretagne/vannes_56260/les-velos-en-libre-service-a-vannes-cest-termine-on-narrive-pas-a-les-revendre_60194053.html