### PR TITLE
Bicing: be exact on ebike flag

### DIFF
--- a/pybikes/bicing.py
+++ b/pybikes/bicing.py
@@ -60,5 +60,6 @@ class BicingStation(BikeShareStation):
             self.extra['normal_bikes'] = int(data['mechanical_bikes'])
 
         if 'electrical_bikes' in data:
-            self.extra['has_ebikes'] = True
-            self.extra['ebikes'] = int(data['electrical_bikes'])
+            ebikes = int(data['electrical_bikes'])
+            self.extra['has_ebikes'] = ebikes > 0
+            self.extra['ebikes'] = ebikes


### PR DESCRIPTION
The field was always true (if the variable was present) regardless of bike availability. This marks it as true if there are actually ebikes available.

Closes https://github.com/eskerda/pybikes/issues/738.