### PR TITLE
do not parse cookies on DB requests

### DIFF
--- a/pybikes/deutschebahn.py
+++ b/pybikes/deutschebahn.py
@@ -38,6 +38,7 @@ class DB(Gbfs):
 
     def update(self, scraper=None):
         scraper = scraper or PyBikesScraper()
+        scraper.parse_cookies = False
         scraper.headers.update(self.auth_headers)
         super(DB, self).update(scraper)
 

--- a/pybikes/utils.py
+++ b/pybikes/utils.py
@@ -34,6 +34,7 @@ class PyBikesScraper(object):
         session=None,
         requests_timeout=300,
         ssl_verification=True,
+        parse_cookies=True,
     ):
         self.headers = headers if isinstance(headers, dict) else {}
         self.headers.setdefault('User-Agent', user_agent)
@@ -49,6 +50,7 @@ class PyBikesScraper(object):
         self.session = session or requests.session()
         self.requests_timeout = requests_timeout
         self.ssl_verification = ssl_verification
+        self.parse_cookies = parse_cookies
 
     def setUserAgent(self, user_agent):
         self.headers['User-Agent'] = user_agent
@@ -92,8 +94,9 @@ class PyBikesScraper(object):
         if raw:
             data = response.content
 
-        if 'set-cookie' in response.headers:
+        if self.parse_cookies and 'set-cookie' in response.headers:
             self.headers['Cookie'] = response.headers['set-cookie']
+
         self.last_request = response
 
         if self.cachedict is not None:


### PR DESCRIPTION
requests with Cookie headers set after Set-Cookie responses where being
rejected by DB gateway

Fix #749 