### PR TITLE
Move torrentbici to nextbike

### DIFF
--- a/pybikes/data/movus.json
+++ b/pybikes/data/movus.json
@@ -8,8 +8,8 @@
                 "city": "Valencia, área metropolitana",
                 "country": "ES",
                 "name": "MIBISI",
-                "latitude": 39.4364,
-                "longitude": -0.4647,
+                "latitude": 39.4745,
+                "longitude": -0.4189,
                 "instances": [
                     {
                         "tag": "horta-sud-en-bici",
@@ -19,16 +19,6 @@
                             "name": "Horta Sud en bici",
                             "latitude": 39.4696,
                             "longitude": -0.4605
-                        }
-                    },
-                    {
-                        "tag": "torrentbici",
-                        "meta": {
-                            "city": "Torrent",
-                            "country": "ES",
-                            "name": "TorrentBici",
-                            "latitude": 39.4319,
-                            "longitude": -0.4730
                         }
                     },
                     {

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -2890,6 +2890,18 @@
                 "latitude": 47.6732,
                 "longitude": 9.1663
             }
+        },
+        {
+            "domain": "en",
+            "tag": "torrentbici",
+            "city_uid": 1056,
+            "meta": {
+                "city": "Torrent",
+                "country": "ES",
+                "name": "TorrentBici",
+                "latitude": 39.4319,
+                "longitude": -0.4730
+            }
         }
     ],
     "system": "nextbike",


### PR DESCRIPTION
Torrentbici has "graduated" from being part of mibisivalencia to a Nextbike service. They removed it from the map and now they have their own section of the site.

This change implements that and moves the coords of mibisivalencia since they were centered around Torrent before.

https://torrentaldia.com/torrentbici-se-renueva-con-100-bicis-electricas-y-19-estaciones/
https://www.mibisivalencia.es/torrentbici/mapa.php
https://www.mibisivalencia.es/mapa/mapa.php

Part of https://github.com/eskerda/pybikes/issues/775.