### PR TITLE
Move bicilog to Nextbike

### DIFF
--- a/pybikes/data/bicicard.json
+++ b/pybikes/data/bicicard.json
@@ -143,17 +143,6 @@
                 "name": "BiciNRivas"
             },
             "tag": "bicinrivas"
-        },
-        {
-            "endpoint": "https://gestion.bicilog.net/prodwservice",
-            "meta": {
-                "city": "Logroño",
-                "country": "ES",
-                "latitude": 42.4658,
-                "longitude": -2.4402,
-                "name": "BiciLog"
-            },
-            "tag": "bicilog"
         }
     ],
     "system": "bicicard"

--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -2902,6 +2902,18 @@
                 "latitude": 39.4319,
                 "longitude": -0.4730
             }
+        },
+        {
+            "domain": "ej",
+            "tag": "bicilog",
+            "city_uid": 1052,
+            "meta": {
+                "city": "Logroño",
+                "country": "ES",
+                "latitude": 42.4658,
+                "longitude": -2.4402,
+                "name": "BiciLog"
+            }
         }
     ],
     "system": "nextbike",


### PR DESCRIPTION
Bicilog has also moved, this time from Bicicard to Nextbike.

https://www.nextbike-bicilog.com/es/
https://logrono.es/-/el-servicio-de-bicilog-se-amplia-con-200-nuevas-bicicletas-50-de-ellas-electricas-y-ya-puede-ser-utilizado-por-toda-la-ciudadania

Part of #775.