### PR TITLE
Update Beryl systems

### DIFF
--- a/pybikes/data/beryl.json
+++ b/pybikes/data/beryl.json
@@ -37,6 +37,28 @@
             "feed_url": "https://gbfs.beryl.cc/v2_2/Cornwall/gbfs.json"
         },
         {
+            "tag": "beryl-dorchester-weymouth-portland",
+            "meta": {
+                "city": "Dorchester, Weymouth and Portland",
+                "name": "Beryl - Dorchester, Weymouth and Portland",
+                "country": "GB",
+                "latitude": 50.6085,
+                "longitude": -2.4540
+            },
+            "feed_url": "https://gbfs.beryl.cc/v2_2/Weymouth/gbfs.json"
+        },
+        {
+            "tag": "beryl-eastleigh",
+            "meta": {
+                "city": "Eastleigh",
+                "name": "Beryl - Eastleigh",
+                "country": "GB",
+                "latitude": 50.9691,
+                "longitude": -1.3603
+            },
+            "feed_url": "https://gbfs.beryl.cc/v2_2/Eastleigh/gbfs.json"
+        },
+        {
             "tag": "beryl-greater-manchester",
             "meta": {
                 "city": "Greater Manchester",
@@ -48,15 +70,16 @@
             "feed_url": "https://gbfs.beryl.cc/v2_2/Greater_Manchester/gbfs.json"
         },
         {
-            "tag": "beryl-hackney-cargo-bike",
+            "tag": "beryl-guildford",
             "meta": {
-                "city": "Hackney",
-                "name": "Beryl - Hackney Cargo Bike",
+                "city": "Guildford",
+                "name": "Beryl - Guildford",
                 "country": "GB",
-                "latitude": 51.5366,
-                "longitude": -0.0751
+                "latitude": 51.2397,
+                "longitude": -0.5764
             },
-            "feed_url": "https://gbfs.beryl.cc/v2_2/Hackney_Cargo_Bike/gbfs.json"
+            "bbox": [[51.1736, -0.7081], [51.3139, -0.4613]],
+            "feed_url": "https://gbfs.beryl.cc/v2_2/Guildford/gbfs.json"
         },
         {
             "tag": "beryl-hereford",
@@ -79,17 +102,6 @@
                 "longitude": -0.2695
             },
             "feed_url": "https://gbfs.beryl.cc/v2_2/Hertsmere/gbfs.json"
-        },
-        {
-            "tag": "beryl-isle-of-wight",
-            "meta": {
-                "city": "Isle of Wight",
-                "name": "Beryl - Isle of Wight",
-                "country": "GB",
-                "latitude": 50.6958,
-                "longitude": -1.2238
-            },
-            "feed_url": "https://gbfs.beryl.cc/v2_2/Isle_of_Wight/gbfs.json"
         },
         {
             "tag": "beryl-leeds",
@@ -125,26 +137,15 @@
             "feed_url": "https://gbfs.beryl.cc/v2_2/Plymouth/gbfs.json"
         },
         {
-            "tag": "beryl-portsmouth",
+            "tag": "beryl-stevenage",
             "meta": {
-                "city": "Portsmouth",
-                "name": "Beryl - Portsmouth",
+                "city": "Stevenage",
+                "name": "Beryl - Stevenage",
                 "country": "GB",
-                "latitude": 50.8035,
-                "longitude": -1.0736
+                "latitude": 51.9059,
+                "longitude": -0.1905
             },
-            "feed_url": "https://gbfs.beryl.cc/v2_2/Portsmouth/gbfs.json"
-        },
-        {
-            "tag": "beryl-southampton",
-            "meta": {
-                "city": "Southampton",
-                "name": "Beryl - Southampton",
-                "country": "GB",
-                "latitude": 50.9021,
-                "longitude": -1.3998
-            },
-            "feed_url": "https://gbfs.beryl.cc/v2_2/Southampton/gbfs.json"
+            "feed_url": "https://gbfs.beryl.cc/v2_2/Stevenage/gbfs.json"
         },
         {
             "tag": "beryl-watford",
@@ -169,26 +170,15 @@
             "feed_url": "https://gbfs.beryl.cc/v2_2/West_Midlands/gbfs.json"
         },
         {
-            "tag": "beryl-westminster-cargo-bike",
+            "tag": "beryl-worcester",
             "meta": {
-                "city": "Westminster",
-                "name": "Beryl - Westminster Cargo Bike",
+                "city": "Worcester",
+                "name": "Beryl - Worcester",
                 "country": "GB",
-                "latitude": 51.5215,
-                "longitude": -0.1840
+                "latitude": 52.4798,
+                "longitude": -1.9014
             },
-            "feed_url": "https://gbfs.beryl.cc/v2_2/Westminster_Cargo_Bike/gbfs.json"
-        },
-        {
-            "tag": "beryl-wool",
-            "meta": {
-                "city": "Wool",
-                "name": "Beryl - Wool",
-                "country": "GB",
-                "latitude": 50.6883,
-                "longitude": -2.2361
-            },
-            "feed_url": "https://gbfs.beryl.cc/v2_2/Wool/gbfs.json"
+            "feed_url": "https://gbfs.beryl.cc/v2_2/Worcester/gbfs.json"
         }
     ]
 }

--- a/pybikes/data/beryl.json
+++ b/pybikes/data/beryl.json
@@ -175,8 +175,8 @@
                 "city": "Worcester",
                 "name": "Beryl - Worcester",
                 "country": "GB",
-                "latitude": 52.4798,
-                "longitude": -1.9014
+                "latitude": 52.1912,
+                "longitude": -2.2206
             },
             "feed_url": "https://gbfs.beryl.cc/v2_2/Worcester/gbfs.json"
         }


### PR DESCRIPTION
New systems:
- beryl-dorchester-weymouth-portland
- beryl-eastleigh
- beryl-guildford
- beryl-stevenage
- beryl-worcester

Defunct systems
- beryl-hackney-cargo-bike (might come back at some point, unusable atm)
- beryl-westminster-cargo-bike (might come back at some point, unusable atm)
- beryl-southampton
- beryl-portsmouth
- beryl-isle-of-wight
- beryl-wool

Reference: https://beryl.cc/where-you-can-hire