### PR TITLE
Retire Youbike v1 feed

### DIFF
--- a/pybikes/youbike.py
+++ b/pybikes/youbike.py
@@ -8,7 +8,6 @@ from pybikes import BikeShareSystem, BikeShareStation, PyBikesScraper
 
 
 class YouBikeTw(BikeShareSystem):
-    FEED_URL_V1 = "https://apis.youbike.com.tw/json/station-yb1.json"
     FEED_URL_V2 = "https://apis.youbike.com.tw/json/station-yb2.json"
 
     unifeed = True
@@ -26,10 +25,7 @@ class YouBikeTw(BikeShareSystem):
 
     def update(self, scraper=None):
         scraper = scraper or PyBikesScraper()
-        v1 = json.loads(scraper.request(self.FEED_URL_V1))
-        v2 = json.loads(scraper.request(self.FEED_URL_V2))
-
-        data = v1 + v2
+        data = json.loads(scraper.request(self.FEED_URL_V2))
         data = filter(
             lambda item: item.get("area_code") == self.uid
             and item.get("lat") != ""


### PR DESCRIPTION
This system used two feeds, the "v1" version and the "v2" versions. They were serving the same data format but v1 was generated by their first generation of bikes/app in some cities and v2 serves the newest version, which was more widespread if i recall correctly. Unfortunately the whole build was failing because the v1 feed stopped working.

Looking at their sites (https://www.youbike.com.tw/region/main/) all the pages are now calling the v2 feed (e.g. https://www.youbike.com.tw/region/taipei/stations/list/) so I think it's safe to remove v1 from the call. My guess is that they managed to move all systems to this feed.