### PR TITLE
fix(vcub): Switch to gbfs

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1160,54 +1160,6 @@
             "feed_url": "https://santana.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         },
         {
-            "tag": "nicosia",
-            "meta": {
-                "latitude": 35.1886,
-                "longitude": 33.3570,
-                "city": "Nicosia",
-                "name": "Nicosia Bike Share",
-                "country": "CY",
-                "company": [
-                    "PBSC Urban Solutions"
-                ]
-            },
-            "bbox": [
-                [
-                    35.044749,
-                    33.175679
-                ],
-                [
-                    35.293126,
-                    33.538914
-                ]
-            ],
-            "feed_url": "https://nicosia.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
-        },
-        {
-            "tag": "famagusta",
-            "meta": {
-                "latitude": 35.1230,
-                "longitude": 33.9346,
-                "city": "Famagusta",
-                "name": "Famagusta Bike Share",
-                "country": "CY",
-                "company": [
-                    "PBSC Urban Solutions"
-                ]
-            },
-            "bbox": [
-                [
-                    35.049682,
-                    33.793569
-                ],
-                [
-                    35.205207,
-                    34.061976
-                ]
-            ],
-            "feed_url": "https://nicosia.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
-        },
-        {
             "tag": "dbizi",
             "meta": {
                 "latitude": 43.3186,

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -597,20 +597,6 @@
             "feed_url": "https://acoruna.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         },
         {
-            "tag": "velocity-aachen",
-            "meta": {
-                "latitude": 50.776667,
-                "city": "Aachen",
-                "name": "Velocity",
-                "longitude": 6.083611,
-                "country": "DE",
-                "company": [
-                    "Velocity Region Aachen GmbH"
-                ]
-            },
-            "feed_url": "https://nitro.openvelo.org/aachen/velocity/v2/gbfs.json"
-        },
-        {
             "tag": "avelo-quebec",
             "meta": {
                 "latitude": 46.81305,
@@ -1103,21 +1089,6 @@
                 "ebikes": true
             },
             "feed_url": "https://detroit.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
-        },
-        {
-            "tag": "green-bike-aruba",
-            "meta": {
-                "latitude": 12.5524,
-                "longitude": -70.0491,
-                "city": "Aruba",
-                "name": "Green Bike",
-                "country": "AW",
-                "company": [
-                    "Friendly Green Bike Company Aruba, V.B.A.",
-                    "PBSC Urban Solutions"
-                ]
-            },
-            "feed_url": "https://aru.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         },
         {
             "tag": "biketown-whq",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1386,6 +1386,18 @@
                     ]
                 },
                 "feed_url": "https://zaragoza.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
+            },
+            {
+                "tag": "v3-bordeaux",
+                "meta": {
+                    "country": "FR",
+                    "city": "Bordeaux",
+                    "latitude": 44.837789,
+                    "longitude": -0.57918,
+                    "company": ["Keolis Bordeaux Métropole"],
+                    "name": "V³"
+                },
+                "feed_url": "https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt"
             }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -938,20 +938,6 @@
             "feed_url": "https://stables.donkey.bike/api/public/gbfs/2/donkey_kreuzlingen/gbfs.json"
         },
         {
-            "tag": "lelocleroule",
-            "meta": {
-                "city": "Le Locle",
-                "name": "LeLocleroule",
-                "country": "CH",
-                "company": [
-                    "Donkey Republic"
-                ],
-                "latitude": 47.0554,
-                "longitude": 6.7466
-            },
-            "feed_url": "https://stables.donkey.bike/api/public/gbfs/2/donkey_le_locle/gbfs.json"
-        },
-        {
             "tag": "neuchatelroule",
             "meta": {
                 "city": "Neuchâtel",

--- a/pybikes/data/keolis.json
+++ b/pybikes/data/keolis.json
@@ -33,22 +33,6 @@
                     "dataset": "vls-stations-etat-tr"
                 }
             ]
-        },
-        "VCub": {
-            "instances": [
-                {
-                    "tag": "v3-bordeaux",
-                    "meta": {
-                        "country": "FR",
-                        "city": "Bordeaux",
-                        "latitude": 44.837789,
-                        "longitude": -0.57918,
-                        "company": ["Keolis Bordeaux Métropole"],
-                        "name": "V³"
-                    },
-                    "feed_url": "https://ws.infotbm.com/ws/1.0/vcubs"
-                }
-            ]
         }
     }
 }

--- a/pybikes/gbfs.py
+++ b/pybikes/gbfs.py
@@ -243,7 +243,10 @@ class GbfsStation(BikeShareStation):
             raise exceptions.StationPlannedException()
 
         self.name = unicode(info['name'])
-        self.bikes = int(info['num_bikes_available'])
+        if 'num_bikes_available' in info:
+            self.bikes = int(info['num_bikes_available'])
+        elif 'num_vehicles_available' in info:
+            self.bikes = int(info['num_vehicles_available']) # In GBFS 3.0, num_bikes_available is replaced by num_vehicles_available https://github.com/MobilityData/gbfs/blob/v3.0/gbfs.md#station_statusjson
 
         if 'num_docks_available' in info:
             self.free = int(info['num_docks_available'])


### PR DESCRIPTION
- Switch Bordeaux VLS from Keolis to GBFS (still keolis operator)
- Added support for GBFS v3 since num_bikes_available is not present anymore in station_status.json
- Remove gbfs that are empty or did not work anymore (502 bad gateway)