### PR TITLE
Update Ecovelo feed

### DIFF
--- a/pybikes/ecovelo.py
+++ b/pybikes/ecovelo.py
@@ -11,7 +11,7 @@ class Ecovelo(Gbfs):
         'company': ['Ecovelo'],
     }
 
-    BASE_URL = "https://api.gbfs.v2.2.ecovelo.mobi/{dataset}/gbfs.json"
+    BASE_URL = "https://api.gbfs.ecovelo.mobi/{dataset}/gbfs.json"
 
     def __init__(self, tag, dataset, meta):
         feed_url = Ecovelo.BASE_URL.format(dataset=dataset)


### PR DESCRIPTION
They moved to Gbfs v3 and the 2.2 feed was dropped, breaking these twenty three systems.

We can hardcode v3 in the url too but I fear that at some point this will be upgraded and will break again. The url without the version seems to redirect to the latest feed.