### PR TITLE
Update Cyclopolis

### DIFF
--- a/pybikes/data/cyclopolis.json
+++ b/pybikes/data/cyclopolis.json
@@ -34,6 +34,17 @@
                     },
                     "mapstyle": "mapbox",
                     "feed_url": "https://edessa.cyclopolis.gr/index.php/en/stations"
+                },
+                 {
+                    "tag": "cyclopolis-poros",
+                    "meta": {
+                        "latitude": 37.4995,
+                        "longitude": 23.4546,
+                        "city": "Poros",
+                        "country": "GR"
+                    },
+                    "mapstyle": "mapbox",
+                    "feed_url": "https://poros.cyclopolis.gr/index.php/en/stations"
                 }
             ]
         },
@@ -48,6 +59,16 @@
                         "country": "GR"
                     },
                     "feed_url": "https://chania.cyclopolis.gr/api/stop/"
+                },
+                {
+                    "tag": "cyclopolis-aua",
+                    "meta": {
+                        "latitude": 37.9846,
+                        "longitude": 23.7056,
+                        "city": "Athens",
+                        "country": "GR"
+                    },
+                    "feed_url": "https://aua.cyclopolis.gr/api/stop/"
                 }
             ]
         }

--- a/pybikes/data/cyclopolis.json
+++ b/pybikes/data/cyclopolis.json
@@ -1,182 +1,56 @@
 {
-    "instances": [
-        {
-            "tag": "cyclopolis-maroussi",
-            "meta": {
-                "latitude": 38.0568722388,
-                "longitude": 23.8083299536,
-                "city": "Maroussi",
-                "country": "GR"
-            },
-            "mapstyle": "google",
-            "feed_url": "https://maroussi.cyclopolis.gr/index.php/en/stations"
+    "class": {
+        "Cyclopolis": {
+            "instances": [
+                {
+                    "tag": "cyclopolis-loutraki",
+                    "meta": {
+                        "latitude": 37.9782137,
+                        "longitude": 22.9767486,
+                        "city": "Loutraki",
+                        "country": "GR"
+                    },
+                    "mapstyle": "mapbox",
+                    "feed_url": "https://loutraki.cyclopolis.gr/index.php/en/stations"
+                },
+                {
+                    "tag": "cyclopolis-igoumenitsa",
+                    "meta": {
+                        "latitude": 39.5031199,
+                        "longitude": 20.2639271,
+                        "city": "Igoumenitsa",
+                        "country": "GR"
+                    },
+                    "mapstyle": "mapbox",
+                    "feed_url": "https://igoumenitsa.cyclopolis.gr/index.php/en/stations"
+                },
+                {
+                    "tag": "cyclopolis-edessa",
+                    "meta": {
+                        "latitude": 40.8033168,
+                        "longitude": 22.0436732,
+                        "city": "Edessa",
+                        "country": "GR"
+                    },
+                    "mapstyle": "mapbox",
+                    "feed_url": "https://edessa.cyclopolis.gr/index.php/en/stations"
+                }
+            ]
         },
-        {
-            "tag": "cyclopolis-nafplio",
-            "meta": {
-                "latitude": 37.5639397319,
-                "longitude": 22.8093402872,
-                "city": "Nafplio",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://nafplio.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-aigialeia",
-            "meta": {
-                "latitude": 38.2511101325,
-                "longitude": 22.0821570196,
-                "city": "Aigialeia",
-                "country": "GR"
-            },
-            "mapstyle": "google",
-            "feed_url": "http://aigialeia.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-marathon",
-            "meta": {
-                "latitude": 38.0855680022,
-                "longitude": 23.9776389963,
-                "city": "Marathon",
-                "country": "GR"
-            },
-            "mapstyle": "google",
-            "feed_url": "http://marathon.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-neasmyrni",
-            "meta": {
-                "latitude": 37.9381,
-                "longitude": 23.7126,
-                "city": "Νea Smyrni",
-                "country": "GR"
-            },
-            "mapstyle": "google",
-            "feed_url": "http://neasmyrni.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-moschatotavros",
-            "meta": {
-                "latitude": 37.9538991434,
-                "longitude": 23.6824746661,
-                "city": "Μoschato-Tavros",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://moschatotavros.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-arxaiaolympia",
-            "meta": {
-                "latitude": 37.6419700934,
-                "longitude": 21.6247265179,
-                "city": "Αrxaia Olympia",
-                "country": "GR"
-            },
-            "mapstyle": "google",
-            "feed_url": "http://arxaiaolympia.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-kiato",
-            "meta": {
-                "latitude": 38.0132674508,
-                "longitude": 22.7493819902,
-                "city": "Kιato",
-                "country": "GR"
-            },
-            "mapstyle": "google",
-            "feed_url": "http://kiato.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-rhodes",
-            "meta": {
-                "latitude": 36.4509118,
-                "longitude": 28.2246966,
-                "city": "Rhodes",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://rhodes.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-florina",
-            "meta": {
-                "latitude": 40.8016111,
-                "longitude": 21.4245222,
-                "city": "Florina",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://florina.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-limnos",
-            "meta": {
-                "latitude": 39.8747861,
-                "longitude": 25.0586722,
-                "city": "Limnos",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "http://limnos.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-loutraki",
-            "meta": {
-                "latitude": 37.9782137,
-                "longitude": 22.9767486,
-                "city": "Loutraki",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://loutraki.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-igoumenitsa",
-            "meta": {
-                "latitude": 39.5031199,
-                "longitude": 20.2639271,
-                "city": "Igoumenitsa",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://igoumenitsa.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-edessa",
-            "meta": {
-                "latitude": 40.8033168,
-                "longitude": 22.0436732,
-                "city": "Edessa",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://edessa.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-syros",
-            "meta": {
-                "latitude": 37.443861,
-                "longitude": 24.9393979,
-                "city": "Syros",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://syros.cyclopolis.gr/index.php/en/stations"
-        },
-        {
-            "tag": "cyclopolis-chania",
-            "meta": {
-                "latitude": 35.5148425,
-                "longitude": 24.0177549,
-                "city": "Chania",
-                "country": "GR"
-            },
-            "mapstyle": "mapbox",
-            "feed_url": "https://chania.cyclopolis.gr/index.php/en/useful-info-en/stations"
+        "CyclopolisApi": {
+            "instances": [
+                {
+                    "tag": "cyclopolis-chania",
+                    "meta": {
+                        "latitude": 35.5148425,
+                        "longitude": 24.0177549,
+                        "city": "Chania",
+                        "country": "GR"
+                    },
+                    "feed_url": "https://chania.cyclopolis.gr/api/stop/"
+                }
+            ]
         }
-    ],
-    "system": "cyclopolis",
-    "class": "Cyclopolis"
+    },
+    "system": "cyclopolis"
 }


### PR DESCRIPTION
Lots of systems were turned off from the feeds on June 2024. They might have migrated somewhere else but they all redirect to the main site on https://www.cyclopolis.gr/index.php/el/cyclopolis-per-municipality.

I discovered a new endpoint for Chania and made a new class, which is also used by the system in the Agricultural University of Athens.