### PR TITLE
Add name to Cyclopolis system

### DIFF
--- a/pybikes/data/cyclopolis.json
+++ b/pybikes/data/cyclopolis.json
@@ -66,6 +66,7 @@
                         "latitude": 37.9846,
                         "longitude": 23.7056,
                         "city": "Athens",
+                        "name": "Γεωπονικό Πανεπιστήμιο Αθηνών (Agricultural University of Athens)",
                         "country": "GR"
                     },
                     "feed_url": "https://aua.cyclopolis.gr/api/stop/"


### PR DESCRIPTION
It's for the Agricultural University of Athens, not just "Athens".