### PR TITLE
Add Austin's CapMetro

### DIFF
--- a/pybikes/data/bcycle.json
+++ b/pybikes/data/bcycle.json
@@ -12,17 +12,6 @@
             }
         },
         {
-            "tag": "austin",
-            "uid": "bcycle_austin",
-            "meta": {
-                "latitude": 30.26408,
-                "longitude": -97.74355,
-                "city": "Austin, TX",
-                "name": "ATX MetroBike",
-                "country": "US"
-            }
-        },
-        {
             "tag": "boulder",
             "uid": "bcycle_boulder",
             "meta": {

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1311,6 +1311,21 @@
                 "name": "V³"
             },
             "feed_url": "https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt"
+        },
+        {
+            "tag": "capmetro-austin",
+            "meta": {
+                "latitude": 30.26408,
+                "longitude": -97.74355,
+                "city": "Austin, TX",
+                "name": "CapMetro Bikeshare",
+                "country": "US",
+                "company": [
+                    "CapMetro",
+                    "City of Austin"
+                ]
+            },
+            "feed_url": "https://austin.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1190,124 +1190,128 @@
             "feed_url": "https://app.kotobike.jp/api/exposed/v2/gbfs/gbfs.json"
         },
         {
-                "tag": "aw-bike",
-                "meta": {
-                    "name": "AW-bike Ahrweiler",
-                    "city": "Ahrweiler",
-                    "country": "DE",
-                    "latitude": 50.5452,
-                    "longitude": 7.1212,
-                    "company": [
-                        "nextbike GmbH"
-                    ]
-                },
-                "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_rh/gbfs.json"
+            "tag": "aw-bike",
+            "meta": {
+                "name": "AW-bike Ahrweiler",
+                "city": "Ahrweiler",
+                "country": "DE",
+                "latitude": 50.5452,
+                "longitude": 7.1212,
+                "company": [
+                    "nextbike GmbH"
+                ]
             },
-            {
-                "tag": "famose",
-                "meta": {
-                    "name": "Fa.Mo.Se",
-                    "city": "Senigallia",
-                    "country": "IT",
-                    "latitude": 43.7603,
-                    "longitude": 13.1139,
-                    "company": [
-                        "Comuni di Senigallia e Mondolfo",
-                        "TIER Mobility SE"
-                    ]
-                },
-                "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_fa/gbfs.json"
+            "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_rh/gbfs.json"
+        },
+        {
+            "tag": "famose",
+            "meta": {
+                "name": "Fa.Mo.Se",
+                "city": "Senigallia",
+                "country": "IT",
+                "latitude": 43.7603,
+                "longitude": 13.1139,
+                "company": [
+                    "Comuni di Senigallia e Mondolfo",
+                    "TIER Mobility SE"
+                ]
             },
-            {
-                "tag": "metrorower",
-                "meta": {
-                    "name": "Metrorower",
-                    "city": "Górnośląsko-Zagłębiowska Metropolia",
-                    "country": "PL",
-                    "latitude": 50.2664,
-                    "longitude": 19.0217,
-                    "company": [
-                        "Górnośląsko-Zagłębiowska Metropolia",
-                        "Nextbike GZM"
-                    ]
-                },
-                "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_zz/gbfs.json"
+            "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_fa/gbfs.json"
+        },
+        {
+            "tag": "metrorower",
+            "meta": {
+                "name": "Metrorower",
+                "city": "Górnośląsko-Zagłębiowska Metropolia",
+                "country": "PL",
+                "latitude": 50.2664,
+                "longitude": 19.0217,
+                "company": [
+                    "Górnośląsko-Zagłębiowska Metropolia",
+                    "Nextbike GZM"
+                ]
             },
-            {
-                "tag": "velhop",
-                "meta": {
-                    "latitude": 48.583611,
-                    "city": "Strasbourg",
-                    "name": "Vélhop",
-                    "longitude": 7.748056,
-                    "country": "FR",
-                    "company": ["Strasbourg Mobilités"]
-                },
-                "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ae/gbfs.json"
+            "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_zz/gbfs.json"
+        },
+        {
+            "tag": "velhop",
+            "meta": {
+                "latitude": 48.583611,
+                "city": "Strasbourg",
+                "name": "Vélhop",
+                "longitude": 7.748056,
+                "country": "FR",
+                "company": [
+                    "Strasbourg Mobilités"
+                ]
             },
-            {
-                "tag": "nextbike-ortenaukreis",
-                "meta": {
-                    "name": "Nextbike Ortenaukreis",
-                    "city": "Ortenaukreis",
-                    "country": "DE",
-                    "latitude": 48.4721,
-                    "longitude": 7.94243,
-                    "company": [
-                        "nextbike GmbH"
-                    ]
-                },
-                "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_eh/gbfs.json"
+            "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ae/gbfs.json"
+        },
+        {
+            "tag": "nextbike-ortenaukreis",
+            "meta": {
+                "name": "Nextbike Ortenaukreis",
+                "city": "Ortenaukreis",
+                "country": "DE",
+                "latitude": 48.4721,
+                "longitude": 7.94243,
+                "company": [
+                    "nextbike GmbH"
+                ]
             },
-            {
-                "tag": "le-velo",
-                "meta": {
-                    "city": "Marseille",
-                    "name": "LeVélo",
-                    "country": "FR",
-                    "company": [
-                        "LeVélo AMP Métropole",
-                        "Ville de Marseille",
-                        "Fifteen SAS"
-                    ],
-                    "longitude": 5.36978,
-                    "latitude": 43.296482,
-                    "source": "https://www.data.gouv.fr/fr/datasets/velos-a-assistance-electrique-en-libre-service-levelo-sur-marseille/",
-                    "license": {
-                        "name": "Open Data Commons Open Database License (ODbL)",
-                        "url": "http://opendatacommons.org/licenses/odbl/summary/"
-                    }
-                },
-                "append_feed_args_to_req": true,
-                "feed_url": "https://api.omega.fifteen.eu/gbfs/2.2/marseille/en/gbfs.json?&key=MjE0ZDNmMGEtNGFkZS00M2FlLWFmMWItZGNhOTZhMWQyYzM2"
+            "feed_url": "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_eh/gbfs.json"
+        },
+        {
+            "tag": "le-velo",
+            "meta": {
+                "city": "Marseille",
+                "name": "LeVélo",
+                "country": "FR",
+                "company": [
+                    "LeVélo AMP Métropole",
+                    "Ville de Marseille",
+                    "Fifteen SAS"
+                ],
+                "longitude": 5.36978,
+                "latitude": 43.296482,
+                "source": "https://www.data.gouv.fr/fr/datasets/velos-a-assistance-electrique-en-libre-service-levelo-sur-marseille/",
+                "license": {
+                    "name": "Open Data Commons Open Database License (ODbL)",
+                    "url": "http://opendatacommons.org/licenses/odbl/summary/"
+                }
             },
-            {
-                "tag": "bizi",
-                "meta": {
-                    "latitude": 41.6487908,
-                    "city": "Zaragoza",
-                    "name": "Bizi",
-                    "longitude": -0.8895811,
-                    "country": "ES",
-                    "company": [
-                        "UTE Serveo Servicios",
-                        "PBSC Urban Solutions"
-                    ]
-                },
-                "feed_url": "https://zaragoza.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
+            "append_feed_args_to_req": true,
+            "feed_url": "https://api.omega.fifteen.eu/gbfs/2.2/marseille/en/gbfs.json?&key=MjE0ZDNmMGEtNGFkZS00M2FlLWFmMWItZGNhOTZhMWQyYzM2"
+        },
+        {
+            "tag": "bizi",
+            "meta": {
+                "latitude": 41.6487908,
+                "city": "Zaragoza",
+                "name": "Bizi",
+                "longitude": -0.8895811,
+                "country": "ES",
+                "company": [
+                    "UTE Serveo Servicios",
+                    "PBSC Urban Solutions"
+                ]
             },
-            {
-                "tag": "v3-bordeaux",
-                "meta": {
-                    "country": "FR",
-                    "city": "Bordeaux",
-                    "latitude": 44.837789,
-                    "longitude": -0.57918,
-                    "company": ["Keolis Bordeaux Métropole"],
-                    "name": "V³"
-                },
-                "feed_url": "https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt"
-            }
+            "feed_url": "https://zaragoza.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
+        },
+        {
+            "tag": "v3-bordeaux",
+            "meta": {
+                "country": "FR",
+                "city": "Bordeaux",
+                "latitude": 44.837789,
+                "longitude": -0.57918,
+                "company": [
+                    "Keolis Bordeaux Métropole"
+                ],
+                "name": "V³"
+            },
+            "feed_url": "https://bdx.mecatran.com/utw/ws/gbfs/bordeaux/v3/gbfs.json?apiKey=opendata-bordeaux-metropole-flux-gtfs-rt"
+        }
     ],
     "system": "gbfs",
     "class": "Gbfs"


### PR DESCRIPTION
This new system replaced Bcycle and is managed by the city's department of transportation. It began in the fall 2024 and will continue to expand this year. 

https://www.capmetro.org/bikeshare
https://www.capmetro.org/news/details/2024/06/27/capmetro-revamps-metrobike-to--capmetro-bikeshare---new-look--new-equipment--new-experience