### PR TITLE
Update Fort Worth

### DIFF
--- a/pybikes/data/bcycle.json
+++ b/pybikes/data/bcycle.json
@@ -45,17 +45,6 @@
             }
         },
         {
-            "tag": "fortworth",
-            "uid": "bcycle_fortworth",
-            "meta": {
-                "latitude": 32.7516,
-                "longitude": -97.32888,
-                "city": "Fort Worth, TX",
-                "name": "Fort Worth Bike Sharing",
-                "country": "US"
-            }
-        },
-        {
             "tag": "omaha",
             "uid": "bcycle_heartland",
             "meta": {

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1334,7 +1334,11 @@
                 "longitude": -97.32888,
                 "city": "Fort Worth, TX",
                 "name": "Trinity Metro Bikes",
-                "country": "US"
+                "country": "US",
+                "company": [
+                    "Trinity Metro",
+                    "Lyft Inc."
+                ]
             },
             "feed_url": "https://fortworth.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         }

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1326,6 +1326,17 @@
                 ]
             },
             "feed_url": "https://austin.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
+        },
+        {
+            "tag": "fortworth",
+            "meta": {
+                "latitude": 32.7516,
+                "longitude": -97.32888,
+                "city": "Fort Worth, TX",
+                "name": "Trinity Metro Bikes",
+                "country": "US"
+            },
+            "feed_url": "https://fortworth.publicbikesystem.net/customer/gbfs/v2/gbfs.json"
         }
     ],
     "system": "gbfs",


### PR DESCRIPTION
The system has moved under a new name.

https://fortworthreport.org/2024/12/02/trinity-metro-shuts-down-fort-worth-bike-sharing-with-plans-for-new-program-in-2025/
https://ridetrinitymetro.org/gtfs-data/