### PR TITLE
Remove Torino bike share

### DIFF
--- a/pybikes/data/bicincitta.json
+++ b/pybikes/data/bicincitta.json
@@ -531,25 +531,6 @@
         },
         {
             "city_ids": [
-                22,
-                61,
-                62,
-                63,
-                64,
-                65
-            ],
-            "meta": {
-                "latitude": 45.07098200000001,
-                "city": "Torino",
-                "name": "[TO]BIKE",
-                "longitude": 7.685676,
-                "country": "IT"
-            },
-            "tag": "to-bike",
-            "endpoint": "http://www.tobike.it/"
-        },
-        {
-            "city_ids": [
                 144
             ],
             "meta": {


### PR DESCRIPTION
Service is no longer active: http://www.comune.torino.it/torinogiovani/vivere-a-torino/bike-sharing-e-noleggio-bici-a-torino

The city has a dockless system in place: https://www.ridemovi.com/it/