### PR TITLE
Update Karlsruhe Nextbike info

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -61,10 +61,10 @@
         },
         {
             "domain": "fg",
-            "tag": "facherrad-karlsruhe",
+            "tag": "nextbike-karlsruhe",
             "city_uid": 21,
             "meta": {
-                "name": "Fächerrad",
+                "name": "KVV.nextbike",
                 "city": "Karlsruhe",
                 "country": "DE",
                 "latitude": 49.0102,


### PR DESCRIPTION
This was renamed from Fächerrad to KVV.nextbike:
https://www.ka-news.de/region/karlsruhe/das-faecherrad-wird-zum-kvv-nextbike-340-neue-drahtesel-in-den-kommenden-wochen-in-karlsruhe-im-einsatz-art-2353632