### PR TITLE
Remove VRN Hockenheim

### DIFF
--- a/pybikes/data/nextbike.json
+++ b/pybikes/data/nextbike.json
@@ -1108,18 +1108,6 @@
         },
         {
             "domain": "vn",
-            "tag": "vrn-hockenheim",
-            "city_uid": 477,
-            "meta": {
-                "name": "VRN",
-                "city": "Hockenheim",
-                "country": "DE",
-                "latitude": 49.3227,
-                "longitude": 8.54258
-            }
-        },
-        {
-            "domain": "vn",
             "tag": "vrn-schwetzingen",
             "city_uid": 480,
             "meta": {


### PR DESCRIPTION
As the city stopped providing the bikes, the system can be removed from citybik.es See also here: https://www.schwetzinger-zeitung.de/orte/hockenheim_artikel,-hockenheim-hockenheim-denkt-nach-aus-von-nextbike-ueber-e-scooter-leihsystem-nach-_arid,2040353.html