### PR TITLE
Remove Cogo and add US west coast Bird, Lime, and Spin GBFS feeds

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1452,20 +1452,6 @@
             "feed_url": "https://data.lime.bike/api/partners/v2/gbfs/san_francisco/gbfs.json"
         },
         {
-            "tag": "revel-san-francisco",
-            "meta": {
-                "latitude": 37.7749,
-                "longitude": -122.4194,
-                "city": "San Francisco, CA",
-                "name": "Revel San Francisco",
-                "country": "US",
-                "company": [
-                    "Revel"
-                ]
-            },
-            "feed_url": "https://gbfs.gorevel.com/gbfs/v2/sanfrancisco/en/gbfs.json"
-        },
-        {
             "tag": "spin-san-francisco",
             "meta": {
                 "latitude": 37.7749,

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1408,6 +1408,34 @@
                 ]
             },
             "feed_url": "https://data.lime.bike/api/partners/v2/gbfs/seattle/gbfs.json"
+        },
+        {
+            "tag": "bird-portland",
+            "meta": {
+                "latitude": 45.5152,
+                "longitude": -122.6784,
+                "city": "Portland, OR",
+                "name": "Bird Portland",
+                "country": "US",
+                "company": [
+                    "Bird Rides, Inc."
+                ]
+            },
+            "feed_url": "https://mds.bird.co/gbfs/v2/public/portland/gbfs.json"
+        },
+        {
+            "tag": "lime-portland",
+            "meta": {
+                "latitude": 45.5152,
+                "longitude": -122.6784,
+                "city": "Portland, OR",
+                "name": "Lime Portland",
+                "country": "US",
+                "company": [
+                    "Lime"
+                ]
+            },
+            "feed_url": "https://data.lime.bike/api/partners/v2/gbfs/portland/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1478,6 +1478,34 @@
                 ]
             },
             "feed_url": "https://mds.bird.co/gbfs/v2/public/provider/spin/san_francisco/gbfs.json"
+        },
+        {
+            "tag": "bird-los-angeles",
+            "meta": {
+                "latitude": 34.0522,
+                "longitude": -118.2437,
+                "city": "Los Angeles, CA",
+                "name": "Bird Los Angeles",
+                "country": "US",
+                "company": [
+                    "Bird Rides, Inc."
+                ]
+            },
+            "feed_url": "https://mds.bird.co/gbfs/v2/public/los-angeles/gbfs.json"
+        },
+        {
+            "tag": "spin-los-angeles",
+            "meta": {
+                "latitude": 34.0522,
+                "longitude": -118.2437,
+                "city": "Los Angeles, CA",
+                "name": "Spin Los Angeles",
+                "country": "US",
+                "company": [
+                    "Bird Rides, Inc."
+                ]
+            },
+            "feed_url": "https://mds.bird.co/gbfs/v2/public/provider/spin/los_angeles/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1380,6 +1380,34 @@
                 ]
             },
             "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/2.2/auray-quiberon/en/gbfs.json"
+        },
+        {
+            "tag": "bird-seattle",
+            "meta": {
+                "latitude": 47.6062,
+                "longitude": -122.3321,
+                "city": "Seattle, WA",
+                "name": "Bird Seattle",
+                "country": "US",
+                "company": [
+                    "Bird Rides, Inc."
+                ]
+            },
+            "feed_url": "https://mds.bird.co/gbfs/v2/public/seattle-washington/gbfs.json"
+        },
+        {
+            "tag": "lime-seattle",
+            "meta": {
+                "latitude": 47.6062,
+                "longitude": -122.3321,
+                "city": "Seattle, WA",
+                "name": "Lime Seattle",
+                "country": "US",
+                "company": [
+                    "Lime"
+                ]
+            },
+            "feed_url": "https://data.lime.bike/api/partners/v1/gbfs/seattle/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -140,22 +140,6 @@
             "feed_url": "https://gbfs.citibikenyc.com/gbfs/gbfs.json"
         },
         {
-            "tag": "cogo",
-            "meta": {
-                "latitude": 39.983333,
-                "longitude": -82.983333,
-                "city": "Columbus, OH",
-                "name": "CoGo",
-                "country": "US",
-                "company": [
-                    "Motivate International, Inc.",
-                    "PBSC Urban Solutions"
-                ],
-                "ebikes": true
-            },
-            "feed_url": "https://gbfs.cogobikeshare.com/gbfs/gbfs.json"
-        },
-        {
             "tag": "denver",
             "meta": {
                 "latitude": 39.72055,

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1407,7 +1407,7 @@
                     "Lime"
                 ]
             },
-            "feed_url": "https://data.lime.bike/api/partners/v1/gbfs/seattle/gbfs.json"
+            "feed_url": "https://data.lime.bike/api/partners/v2/gbfs/seattle/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1436,6 +1436,48 @@
                 ]
             },
             "feed_url": "https://data.lime.bike/api/partners/v2/gbfs/portland/gbfs.json"
+        },
+        {
+            "tag": "lime-san-francisco",
+            "meta": {
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "city": "San Francisco, CA",
+                "name": "Lime San Francisco",
+                "country": "US",
+                "company": [
+                    "Lime"
+                ]
+            },
+            "feed_url": "https://data.lime.bike/api/partners/v2/gbfs/san_francisco/gbfs.json"
+        },
+        {
+            "tag": "revel-san-francisco",
+            "meta": {
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "city": "San Francisco, CA",
+                "name": "Revel San Francisco",
+                "country": "US",
+                "company": [
+                    "Revel"
+                ]
+            },
+            "feed_url": "https://gbfs.gorevel.com/gbfs/v2/sanfrancisco/en/gbfs.json"
+        },
+        {
+            "tag": "spin-san-francisco",
+            "meta": {
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "city": "San Francisco, CA",
+                "name": "Spin San Francisco",
+                "country": "US",
+                "company": [
+                    "Bird Rides, Inc."
+                ]
+            },
+            "feed_url": "https://mds.bird.co/gbfs/v2/public/provider/spin/san_francisco/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -62,9 +62,6 @@ class BaseInstanceTest(object):
 
     @pytest.mark.update
     def test_update(self, instance, i_data, cls, mod, record_property):
-        if instance.tag == "cogo":  # Cogo is currently broken
-            return
-
         scraper = pybikes.PyBikesScraper(
             # use a simple dict cache for systems that use a single endpoint
             cachedict=cache if instance.unifeed else None,

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -62,6 +62,9 @@ class BaseInstanceTest(object):
 
     @pytest.mark.update
     def test_update(self, instance, i_data, cls, mod, record_property):
+        if instance.tag == "cogo":  # Cogo is currently broken
+            return
+
         scraper = pybikes.PyBikesScraper(
             # use a simple dict cache for systems that use a single endpoint
             cachedict=cache if instance.unifeed else None,


### PR DESCRIPTION
related to #799 

removed cogo because it ended service at the end of Feb 2025.