### PR TITLE
feat(ecovelo): add saint-Pierre BSS

### DIFF
--- a/pybikes/data/ecovelo.json
+++ b/pybikes/data/ecovelo.json
@@ -276,6 +276,18 @@
                         "country": "FR"
                     },
                     "dataset": "choletbus"
+                },
+                {
+                    "tag": "altervelo",
+                    "meta": {
+                        "city": "Saint-Pierre",
+                        "name": "alterVélo libre service",
+                        "ebikes": true,
+                        "latitude": -21.3414,
+                        "longitude": 55.4777,
+                        "country": "FR"
+                    },
+                    "dataset": "altervelo"
                 }
             ]
         }


### PR DESCRIPTION
add bike sharing system for Saint-Pierre, La Réunion, France
[gbfs informations](https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-saint-pierre-la-reunion-civis-altervelo)