### PR TITLE
[bicicard] New systems in Villarcayo, Cenicientos and Castro-Urdiales

### DIFF
--- a/pybikes/data/bicicard.json
+++ b/pybikes/data/bicicard.json
@@ -132,6 +132,39 @@
                 "name": "BiciBur"
             },
             "tag": "bicibur"
+        },
+        {
+            "endpoint": "https://services.villarcayo.bicicard.es",
+            "meta": {
+                "city": "Villarcayo",
+                "country": "ES",
+                "latitude": 42.9384,
+                "longitude":  -3.5724,
+                "name": "Vive Villarcayo"
+            },
+            "tag": "vive-villarcayo"
+        },
+        {
+            "endpoint": "https://services.cenicientos.bicicard.es",
+            "meta": {
+                "city": "Cenicientos",
+                "country": "ES",
+                "latitude": 40.2623,
+                "longitude": -4.4661,
+                "name": "Cenibici"
+            },
+            "tag": "cenibici"
+        },
+        {
+            "endpoint": "https://services.castro.bicicard.es",
+            "meta": {
+                "city": "Castro-Urdiales",
+                "country": "ES",
+                "latitude": 43.3849,
+                "longitude": -3.2181,
+                "name": "BiciCastro"
+            },
+            "tag": "bicicastro"
         }
     ],
     "system": "bicicard"


### PR DESCRIPTION
- Villarcayo: https://www.diariodeburgos.es/noticia/z3510b0e8-0696-2441-abb1da8135905823/202404/villarcayo-estrena-bicicletas-electricas-de-alquiler
- Cenicientos: https://cenicientosdigital.es/1251/deportes/#:~:text=%F0%9F%9A%B4%E2%80%8D%E2%99%82%EF%B8%8F,aventureros
- Castro-Urdiales: https://micastro.castro-urdiales.net/servicios-ciudadania/informacion/servicio-de-prestamos-de-bicicletas-y-patinetes-electrico-y-de-aparcamientos-seguros-bicicastro