### PR TITLE
Add Nîmes network NemoVélo in Ecovelo network list

### DIFF
--- a/pybikes/data/ecovelo.json
+++ b/pybikes/data/ecovelo.json
@@ -288,6 +288,18 @@
                         "country": "FR"
                     },
                     "dataset": "altervelo"
+                },
+                {
+                    "tag": "nemovelo",
+                    "meta": {
+                        "city": "Nîmes",
+                        "name": "NemoVélo",
+                        "ebikes": true,
+                        "latitude": 43.83819,
+                        "longitude": 4.35997,
+                        "country": "FR"
+                    },
+                    "dataset": "nemovelo"
                 }
             ]
         }


### PR DESCRIPTION
Hi,
Last summer, Nîmes launched its NemoVélo network, managed by Ecovelo. So I added this network to the list of Ecovelo networks.

This is my first PR, and I just filled in the json without testing anything afterwards, so let me know if something's wrong.

Thanks!

https://transport.data.gouv.fr/datasets/velos-a-assistance-electrique-en-libre-service-nimes-metropole-nemovelo

https://www.vivrenimes.fr/formats/articles/nemovelo-comment-ca-marche