### PR TITLE
Add new Fifteen networks

### DIFF
--- a/pybikes/data/fifteen.json
+++ b/pybikes/data/fifteen.json
@@ -19,20 +19,6 @@
             "feed_url": "https://bici.gijon.es/api/client/entities"
         },
         {
-            "tag": "auxrmlevelo",
-            "meta": {
-                "city": "Auxerre",
-                "name": "AuxR_M le vélo",
-                "country": "FR",
-                "company": [
-                    "Fifteen SAS"
-                ],
-                "longitude": 3.572376,
-                "latitude": 47.797221
-            },
-            "feed_url": "https://auxrmlevelo.com/api/client/entities"
-        },
-        {
             "tag": "velomodalis",
             "meta": {
                 "city": "Ligne TER Royan - Angoulême",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1481,6 +1481,60 @@
                 "longitude": -0.3685668
             },
             "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/pau/gbfs.json"
+        },
+        {
+            "tag": "auxrm",
+            "meta": {
+                "name": "AuxR_M",
+                "city": "Auxerre",
+                "country": "FR",
+                "company": [
+                    "Fifteen SAS"
+                ],
+                "latitude": 47.796054,
+                "longitude": 3.571375
+            },
+            "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/auxerre/gbfs.json"
+        },
+        {
+            "tag": "velofluo",
+            "meta": {
+                "name": "Vélo Fluo",
+                "country": "FR",
+                "company": [
+                    "Fifteen SAS"
+                ],
+                "latitude": 48.484322,
+                "longitude": 6.114004
+            },
+            "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/velo-fluo/gbfs.json"
+        },
+        {
+            "tag": "modalis",
+            "meta": {
+                "name": "Modalis",
+                "country": "FR",
+                "company": [
+                    "Fifteen SAS"
+                ],
+                "latitude": 45.403896,
+                "longitude": 0.376046
+            },
+            "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/velo-modalis/gbfs.json"
+        },
+        {
+            "tag": "brennus",
+            "meta": {
+                "name": "Brennus à vélo",
+                "city": "Sens",
+                "country": "FR",
+                "company": [
+                    "Fifteen SAS"
+                ],
+                "latitude": 48.197815,
+                "longitude": 3.282785
+            },
+            "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/sens/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1483,7 +1483,7 @@
             "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/pau/gbfs.json"
         },
         {
-            "tag": "auxrm",
+            "tag": "auxrmlevelo",
             "meta": {
                 "name": "AuxR_M",
                 "city": "Auxerre",
@@ -1499,6 +1499,7 @@
         {
             "tag": "velofluo",
             "meta": {
+				"city": "Grand Est",
                 "name": "Vélo Fluo",
                 "country": "FR",
                 "company": [
@@ -1508,19 +1509,6 @@
                 "longitude": 6.114004
             },
             "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/velo-fluo/gbfs.json"
-        },
-        {
-            "tag": "modalis",
-            "meta": {
-                "name": "Modalis",
-                "country": "FR",
-                "company": [
-                    "Fifteen SAS"
-                ],
-                "latitude": 45.403896,
-                "longitude": 0.376046
-            },
-            "feed_url": "https://gbfs.partners.fifteen.eu/gbfs/velo-modalis/gbfs.json"
         },
         {
             "tag": "brennus",


### PR DESCRIPTION
Fixes #880 

I have added new Fifteen networks by re-using same logic as Epinal or Pau
This PR adds region networks, for these cases I don't have added city field and to set latitude and longitude field, I have used the center of the region