### PR TITLE
Bump to latest Github actions in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -33,9 +33,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: pip

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,11 +7,11 @@ jobs:
   sync-nextbike:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.SYNC_TOKEN }}
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Install dependencies
@@ -21,7 +21,7 @@ jobs:
           python utils/sync_nextbike.py > nextbike.json
           mv nextbike.json pybikes/data/nextbike.json
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.SYNC_TOKEN }}
           commit-message: update nextbike feeds

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -51,11 +51,11 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
     - name: Install dependencies
@@ -74,9 +74,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.9'
     - name: Install dependencies


### PR DESCRIPTION
This PR switch to latest Github actions because Node 20 version used in old GH actions is deprecated https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

- [Checkout](https://github.com/actions/checkout/releases/tag/v6.0.0)
- [Setup-python](https://github.com/actions/setup-python/releases/tag/v6.0.0)
- [create-pull-request](https://github.com/peter-evans/create-pull-request/releases/tag/v8.0.0)