### PR TITLE
OpenSourceBikeShareV2: switch to GBFS

### DIFF
--- a/keys.example.py
+++ b/keys.example.py
@@ -17,6 +17,3 @@ deutschebahn = {
 sharedmobility = 'a-valid@email-address'
 
 bikeshare_ie = '<some token>'
-
-# See https://github.com/cyklokoalicia/OpenSourceBikeShare/blob/main/Access%20the%20data.md
-open_source_bike_share_v2 = '<some token>'

--- a/pybikes/data/open_source_bike_share_v2.json
+++ b/pybikes/data/open_source_bike_share_v2.json
@@ -9,7 +9,7 @@
         "longitude": 17.113922,
         "country": "SK"
       },
-      "feed_url": "https://whitebikes.info/api/stand/markers"
+      "feed_url": "https://whitebikes.info/gbfs.json"
     }
   ],
   "system": "open_source_bike_share_v2",

--- a/pybikes/open_source_bike_share_v2.py
+++ b/pybikes/open_source_bike_share_v2.py
@@ -1,24 +1,11 @@
 # -*- coding: utf-8 -*-
 # Distributed under the AGPL license, see LICENSE.txt
 
-import json
-
-from pybikes import utils
-from pybikes.open_source_bike_share import OpenSourceBikeShare
+from pybikes.gbfs import Gbfs
 
 
-class OpenSourceBikeShareV2(OpenSourceBikeShare):
-    authed = True
-
-    def __init__(self, tag, meta, feed_url, key):
-        super().__init__(tag, meta, feed_url)
-        self.key = key
-
-    def update(self, scraper=None):
-        scraper = scraper or utils.PyBikesScraper()
-        scraper.parse_cookies = False
-        scraper.headers.update({
-            'Authorization': 'Bearer %s' % self.key,
-        })
-
-        super().update(scraper=scraper)
+class OpenSourceBikeShareV2(Gbfs):
+    meta = {
+        'system': 'Open Source Bike Share',
+        'company': ['Open Source Bike Share'],
+    }


### PR DESCRIPTION
## Summary

OpenSourceBikeShare web exposes a standards-compliant GBFS v2.3 manifest at `/gbfs.json` as of release v1.1.x. With that live, the bearer-token markers scraper introduced in #831 is no longer needed.

This PR makes `OpenSourceBikeShareV2` a thin `Gbfs` subclass, mirroring the existing `NextbikeGbfs` pattern, and points the `whitebikes` instance at `https://whitebikes.info/gbfs.json`.

## Changes

- `pybikes/open_source_bike_share_v2.py` — `OpenSourceBikeShareV2(Gbfs)` with default `meta` (`system`, `company`). Drops `key`, `authed = True`, and the bearer-token override.
- `pybikes/data/open_source_bike_share_v2.json` — `feed_url` → `https://whitebikes.info/gbfs.json`.
- `keys.example.py` — drops the `open_source_bike_share_v2` token entry, no longer needed.

The class name, system tag, file paths, and the `whitebikes` instance tag are unchanged. Existing callers of `pybikes.get('whitebikes')` keep working — they just no longer need a `key=` argument.

## Test plan

- [x] `pytest tests/ -m "not update"` — 2397 passed locally.
- [x] `pytest tests/test_changes.py` (with origin = upstream/master) — `TestOpenSourceBikeShareV2` test_tag_unique / test_fields / test_uses_scraper all pass.
- [x] Live `update()` against `https://whitebikes.info/gbfs.json` — 126 stations parsed, `last_reported`, `is_renting`/`is_returning`, `is_virtual_station` all populated; `meta.gbfs_href` set as expected.