### PR TITLE
[vlille] Move to GBFS endpoint

### DIFF
--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1558,7 +1558,12 @@
                 "name": "V'Lille",
                 "longitude": 3.057256,
                 "company": ["Keolis", "ilévia"],
-                "country": "FR"
+                "country": "FR",
+                "source": "https://transport.data.gouv.fr/datasets/ilevia-vlille-disponibilite-en-temps-reel",
+                "license": {
+                    "name": "Licence Ouverte 2.0",
+                    "url": "https://www.data.gouv.fr/pages/legal/licences/etalab-2.0"
+                }
             },
             "feed_url":  "https://media.ilevia.fr/opendata/gbfs.json"
         }

--- a/pybikes/data/gbfs.json
+++ b/pybikes/data/gbfs.json
@@ -1549,6 +1549,18 @@
                 "longitude": 6.083856
             },
             "feed_url": "https://gbfs.api.ridedott.com/public/v2/aachen/gbfs.json"
+        },
+        {
+            "tag": "vlille",
+            "meta": {
+                "latitude": 50.62925,
+                "city": "Lille",
+                "name": "V'Lille",
+                "longitude": 3.057256,
+                "company": ["Keolis", "ilévia"],
+                "country": "FR"
+            },
+            "feed_url":  "https://media.ilevia.fr/opendata/gbfs.json"
         }
     ],
     "system": "gbfs",

--- a/pybikes/data/keolis.json
+++ b/pybikes/data/keolis.json
@@ -1,22 +1,6 @@
 {
     "system": "keolis",
     "class": {
-        "KeolisIlevia": {
-            "instances": [
-                {
-                    "tag": "vlille",
-                    "meta": {
-                        "latitude": 50.62925,
-                        "city": "Lille",
-                        "name": "V'Lille",
-                        "longitude": 3.057256,
-                        "country": "FR",
-                        "source":  "https://data.lillemetropole.fr/catalogue/dataset/c8166e8f-36a2-40ca-af1a-a00ab1fb20f7"
-                    },
-                    "dataset": "ilevia:vlille_temps_reel"
-                }
-            ]
-        },
         "KeolisSTAR": {
             "instances": [
                 {


### PR DESCRIPTION
Looks like the moved to a GBFS endpoint and abandoned the other one.

Found here: https://transport.data.gouv.fr/datasets/ilevia-vlille-disponibilite-en-temps-reel

Closes https://github.com/eskerda/pybikes/issues/897.